### PR TITLE
Fetch public IP without aws-lib.

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -74,7 +74,6 @@ var addToCloudHandler = function (callback) {
         k2,
         address;
 
-
     for (k in interfaces) {
         if (interfaces.hasOwnProperty(k)) {
             for (k2 in interfaces[k]) {
@@ -87,7 +86,6 @@ var addToCloudHandler = function (callback) {
             }
         }
     }
-
     publicIP = addresses[0];
     privateRegexp = new RegExp(publicIP, 'g');
 
@@ -134,7 +132,25 @@ var addToCloudHandler = function (callback) {
 
         });
     };
-    addECToCloudHandler(5);
+
+    if (config.cloudProvider.name === 'amazon') {
+        http.get('http://169.254.169.254/latest/meta-data/public-ipv4', function (response) {
+            var content = '';
+            response.on('data', function(chunk) {
+                content += chunk;
+            });
+            response.on('end', function() {
+                console.log('public IP: ', content);
+                publicIP = content;
+                addECToCloudHandler(5);
+            });
+        }).on('error', function(err) {
+            console.log('Error: ', err);
+        });
+    } else {
+        addECToCloudHandler(5);
+    }
+
 };
 
 //*******************************************************************

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -14,7 +14,7 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-npm install --loglevel error amqp express mongodb mongojs aws-lib
+npm install --loglevel error amqp express mongodb mongojs
 
 echo [nuve] Done, node_modules installed
 

--- a/nuve/nuveAPI/cloudHandler.js
+++ b/nuve/nuveAPI/cloudHandler.js
@@ -1,7 +1,6 @@
 /*global require, console, setInterval, clearInterval, exports*/
 var rpc = require('./rpc/rpc');
 var config = require('./../../licode_config');
-var ec2;
 
 var INTERVAL_TIME_EC_READY = 100;
 var INTERVAL_TIME_CHECK_KA = 1000;
@@ -81,40 +80,8 @@ var recalculatePriority = function () {
 exports.addNewErizoController = function (msg, callback) {
     "use strict";
 
-    if (msg.cloudProvider === '') {
-        addNewPrivateErizoController(msg.ip, callback);
-    } else if (msg.cloudProvider === 'amazon') {
-        addNewAmazonErizoController(msg.ip, callback);
-    }
-    
+    addNewPrivateErizoController(msg.ip, callback);
 };
-
-var addNewAmazonErizoController = function(privateIP, callback) {
-    
-    var publicIP;
-    var instaceId;
-
-    if (ec2 === undefined) {
-        var opt = {version: '2012-12-01'};
-        if (config.cloudProvider.host !== '') {
-            opt.host = config.cloudProvider.host;
-        }
-        ec2 = require('aws-lib').createEC2Client(config.cloudProvider.accessKey, config.cloudProvider.secretAccessKey, opt);
-    }
-    console.log('private ip ', privateIP);
-
-    ec2.call('DescribeInstances', {'Filter.1.Name':'private-ip-address', 'Filter.1.Value':privateIP}, function (err, response) {
-
-        if (err) {
-            console.log('Error: ', err);
-            callback('error');
-        } else if (response) {
-            publicIP = response.reservationSet.item.instancesSet.item.ipAddress;
-            console.log('public IP: ', publicIP);
-            addNewPrivateErizoController(publicIP, callback);
-        }
-    });
-}
 
 var addNewPrivateErizoController = function (ip, callback) {
     "use strict";

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -41,10 +41,6 @@ config.erizo.minport = 0;
 config.erizo.maxport = 0;
 
 config.cloudProvider.name = '';
-//In Amazon Ec2 instances you can specify the zone host. By default is 'ec2.us-east-1a.amazonaws.com' 
-config.cloudProvider.host = '';
-config.cloudProvider.accessKey = '';
-config.cloudProvider.secretAccessKey = '';
 
 // Roles to be used by services
 config.roles = {"presenter":["publish", "subscribe", "record"], "viewer":["subscribe"]};


### PR DESCRIPTION
AWS provides metadata about each EC2 instance at
http://169.254.169.254/latest/meta-data.  By making use of this metadata,
licode no longer requires AWS credentials.