### PR TITLE
Shell Script Improvements for Smoother Deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+npm-debug.log
 build/
 licode_config.js
 extras/basic_example/node_modules
@@ -10,5 +11,6 @@ scripts/libdeps/
 libdeps/
 extras/vagrant/.vagrant
 extras/vagrant/licode/
+erizo_controller/erizoController/core
 erizo_controller/erizoAgent/out.log
 erizo_controller/erizoAgent/erizo-*.log

--- a/erizo/buildProject.sh
+++ b/erizo/buildProject.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 runcmake() {
    cmake ../src
    echo "Done"

--- a/erizo/generateProject.sh
+++ b/erizo/generateProject.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 runcmake() {
    cmake ../src
    echo "Done"

--- a/erizoAPI/build.sh
+++ b/erizoAPI/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 if hash node-waf 2>/dev/null; then
   echo 'building with node-waf'
   rm -rf build

--- a/erizo_controller/erizoClient/tools/compile.sh
+++ b/erizo_controller/erizoClient/tools/compile.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -e
+
 java -jar compiler.jar --js ../lib/socket.io.js --js ../src/Events.js --js ../src/webrtc-stacks/FcStack.js --js ../src/webrtc-stacks/FirefoxStack.js --js ../src/webrtc-stacks/ChromeStableStack.js --js ../src/webrtc-stacks/ChromeCanaryStack.js --js ../src/Connection.js --js ../src/Stream.js --js ../src/Room.js --js ../src/utils/L.Logger.js --js ../src/utils/L.Base64.js --js ../src/utils/L.Resizer.js --js ../src/views/View.js --js ../src/views/VideoPlayer.js --js ../src/views/AudioPlayer.js --js ../src/views/Bar.js --js ../src/views/Speaker.js --js_output_file ../dist/erizo.js

--- a/erizo_controller/erizoClient/tools/compile.sh
+++ b/erizo_controller/erizoClient/tools/compile.sh
@@ -3,3 +3,4 @@
 set -e
 
 java -jar compiler.jar --js ../lib/socket.io.js --js ../src/Events.js --js ../src/webrtc-stacks/FcStack.js --js ../src/webrtc-stacks/FirefoxStack.js --js ../src/webrtc-stacks/ChromeStableStack.js --js ../src/webrtc-stacks/ChromeCanaryStack.js --js ../src/Connection.js --js ../src/Stream.js --js ../src/Room.js --js ../src/utils/L.Logger.js --js ../src/utils/L.Base64.js --js ../src/utils/L.Resizer.js --js ../src/views/View.js --js ../src/views/VideoPlayer.js --js ../src/views/AudioPlayer.js --js ../src/views/Bar.js --js ../src/views/Speaker.js --js_output_file ../dist/erizo.js
+cp ../dist/erizo.js ../../../extras/basic_example/public

--- a/erizo_controller/erizoClient/tools/compileDebug.sh
+++ b/erizo_controller/erizoClient/tools/compileDebug.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 FILE=../dist/erizo.js
-rm $FILE
+rm -f $FILE
 cat ../lib/socket.io.js >> $FILE
 cat ../src/Events.js >> $FILE
 cat ../src/webrtc-stacks/FcStack.js >> $FILE
@@ -19,3 +19,4 @@ cat ../src/views/VideoPlayer.js >> $FILE
 cat ../src/views/AudioPlayer.js >> $FILE
 cat ../src/views/Bar.js >> $FILE
 cat ../src/views/Speaker.js >> $FILE
+cp ../dist/erizo.js ../../../extras/basic_example/public

--- a/erizo_controller/erizoClient/tools/compileDebug.sh
+++ b/erizo_controller/erizoClient/tools/compileDebug.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 FILE=../dist/erizo.js
 rm $FILE
 cat ../lib/socket.io.js >> $FILE

--- a/erizo_controller/erizoClient/tools/compilefc.sh
+++ b/erizo_controller/erizoClient/tools/compilefc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -d $LIB_DIR ]; then
 	rm -rf ../build
 fi

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo [erizo_controller] Installing node_modules for erizo_controller
 
 npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`

--- a/nuve/nuveClient/tools/compile.sh
+++ b/nuve/nuveClient/tools/compile.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-mkdir ../dist
-mkdir ../build
+set -e
+
+mkdir -p ../dist
+mkdir -p ../build
 
 java -jar compiler.jar --js ../src/hmac-sha1.js --js ../src/N.js --js ../src/N.Base64.js --js ../src/N.API.js --js_output_file ../build/nuve.js
 

--- a/nuve/nuveClient/tools/compileDist.sh
+++ b/nuve/nuveClient/tools/compileDist.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 java -jar compiler.jar --js ../lib/xmlhttprequest.js --js_output_file ../dist/xmlhttprequest.js
 
 TARGET=../dist/nuve.js

--- a/scripts/installBasicExample.sh
+++ b/scripts/installBasicExample.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e 
+
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`

--- a/scripts/installBasicExample.sh
+++ b/scripts/installBasicExample.sh
@@ -13,6 +13,9 @@ EXTRAS=$ROOT/extras
 
 cd $EXTRAS/basic_example
 
-npm install --loglevel error express@3.4.8
+npm install --loglevel error express@3.5.1
+
+cp -r $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
+cp -r $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
 
 cd $CURRENT_DIR

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e 
+
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`

--- a/scripts/installNuve.sh
+++ b/scripts/installNuve.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -44,11 +44,11 @@ check_proxy(){
 }
 
 install_apt_deps(){
-  sudo apt-get install python-software-properties
-  sudo apt-get install software-properties-common
-  sudo add-apt-repository ppa:chris-lea/node.js
-  sudo apt-get update
-  sudo apt-get install git make gcc g++ libssl-dev cmake libglib2.0-dev pkg-config nodejs libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb openjdk-6-jre curl libboost-test-dev
+  sudo apt-get install -y python-software-properties
+  sudo apt-get install -y software-properties-common
+  sudo add-apt-repository -y ppa:chris-lea/node.js
+  sudo apt-get -y update
+  sudo apt-get -y install git make gcc g++ libssl-dev cmake libglib2.0-dev pkg-config nodejs libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb openjdk-6-jre curl libboost-test-dev
   sudo npm install -g node-gyp
   sudo chown -R `whoami` ~/.npm ~/tmp/
 }
@@ -99,7 +99,7 @@ install_opus(){
 }
 
 install_mediadeps(){
-  sudo apt-get install yasm libvpx. libx264.
+  sudo apt-get -y install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     curl -O https://www.libav.org/releases/libav-9.13.tar.gz
@@ -117,7 +117,7 @@ install_mediadeps(){
 }
 
 install_mediadeps_nogpl(){
-  sudo apt-get install yasm libvpx.
+  sudo apt-get -y install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     curl -O https://www.libav.org/releases/libav-9.13.tar.gz

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -9,10 +9,6 @@ CURRENT_DIR=`pwd`
 LIB_DIR=$BUILD_DIR/libdeps
 PREFIX_DIR=$LIB_DIR/build/
 
-pause() {
-  read -p "$*"
-}
-
 parse_arguments(){
   while [ "$1" != "" ]; do
     case $1 in
@@ -33,14 +29,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 install_apt_deps(){
@@ -143,7 +139,7 @@ install_libsrtp(){
 }
 
 
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*
@@ -158,28 +154,28 @@ parse_arguments $*
 
 mkdir -p $PREFIX_DIR
 
-pause "Installing deps via apt-get... [press Enter]"
+echo "Installing deps via apt-get... [press Enter]"
 install_apt_deps
 
 check_proxy
 
-pause "Installing openssl library...  [press Enter]"
+echo "Installing openssl library...  [press Enter]"
 install_openssl
 
-pause "Installing libnice library...  [press Enter]"
+echo "Installing libnice library...  [press Enter]"
 install_libnice
 
-pause "Installing libsrtp library...  [press Enter]"
+echo "Installing libsrtp library...  [press Enter]"
 install_libsrtp
 
-pause "Installing opus library...  [press Enter]"
+echo "Installing opus library...  [press Enter]"
 install_opus
 
 if [ "$ENABLE_GPL" = "true" ]; then
-  pause "GPL libraries enabled"
+  echo "GPL libraries enabled"
   install_mediadeps
 else
-  pause "No GPL libraries enabled, this disables h264 transcoding, to enable gpl please use the --enable-gpl option"
+  echo "No GPL libraries enabled, this disables h264 transcoding, to enable gpl please use the --enable-gpl option"
   install_mediadeps_nogpl
 fi
 


### PR DESCRIPTION
- Using `set -e` to exit scripts on error.
- Using `apt-get -y` so scripts install without prompt.
- Couple other little fixes.