### PR TITLE
put all npm dependencies in package.json and version lock

### DIFF
--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -2,7 +2,9 @@
 
 echo [erizo_controller] Installing node_modules for erizo_controller
 
-npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt
+# this is in ging master.  But I added these to package.json to version lock.
+#npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt
+npm install
 
 echo [erizo_controller] Done, node_modules installed
 

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -14,7 +14,10 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-npm install --loglevel error amqp express@3 mongojs aws-lib log4js node-getopt
+
+# this is in ging master.  But I added these to package.json to version lock.
+#npm install --loglevel error amqp express@3 mongojs aws-lib log4js node-getopt
+npm install --loglevel error
 
 echo [nuve] Done, node_modules installed
 

--- a/package.json
+++ b/package.json
@@ -3,19 +3,26 @@
   "version": "0.1.0",
   "description": "Open Source Communication Provider",
   "devDependencies": {
-    "vows": "0.6.x",
+    "amqp": "~0.2.0",
+    "aws-lib": "~0.3.0",
     "coffee-script": "1.4.x",
-    "winston": "~0.7.2",
-    "karma-script-launcher": "~0.1.0",
+    "express": "~3.5.1",
+    "jasmine-node": "~1.11.0",
+    "karma": "~0.12.17",
+    "karma-chrome-launcher": "~0.1.0",
+    "karma-coffee-preprocessor": "~0.1.0",
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
-    "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
-    "karma": "~0.10.2",
-    "karma-chrome-launcher": "~0.1.0",
-    "jasmine-node": "~1.11.0"
+    "karma-requirejs": "~0.1.0",
+    "karma-script-launcher": "~0.1.0",
+    "log4js": "~0.6.20",
+    "mongojs": "~0.11.1",
+    "node-getopt": "~0.2.3",
+    "socket.io": "~0.9.16",
+    "vows": "0.6.x",
+    "winston": "~0.7.2"
   },
   "contributors": [
     {
@@ -33,5 +40,8 @@
   ],
   "scripts": {
     "test": " ./node_modules/jasmine-node/bin/jasmine-node test/;karma start test/karma.conf.js"
+  },
+  "dependencies": {
+    "body-parser": "1.0.2"
   }
 }


### PR DESCRIPTION
We have found that version-locking NPM dependencies makes maintaining our licode servers a lot easier.  