### PR TITLE
Separate Host-Specific Configuration to host.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+licode_config/
 licode_config.js
 extras/basic_example/node_modules
 extras/basic_example/public/erizo.js

--- a/scripts/default_host_config.js
+++ b/scripts/default_host_config.js
@@ -1,0 +1,25 @@
+var host_config = {};
+
+/*
+ * Host-specific configuration included by licode_config.js
+ * Intended so that puppet/chef/etc. deployment scripts can simply
+ * create file and not have to edit licode_config.js
+ */
+
+/* If the erizo controller uses SSL, you need to set a public hostname,
+ * and make sure your SSL certs are set up properly.
+ */
+host_config.publicHostname = '';
+
+/* Override this if you are behind a NAT */
+host_config.publicIP = '';
+
+/* Override this if you are using a cloud provider (e.g. 'amazon') */
+host_config.cloudProviderName = '';
+
+// override if you don't want to use defaults.
+host_config.minport = 0;
+host_config.maxport = 0;
+
+module.exports = host_config;
+

--- a/scripts/host_default.js
+++ b/scripts/host_default.js
@@ -17,7 +17,7 @@ host_config.publicIP = '';
 /* Override this if you are using a cloud provider (e.g. 'amazon') */
 host_config.cloudProviderName = '';
 
-// override if you don't want to use defaults.
+/* override if you don't want to use licode's default port range */
 host_config.minport = 0;
 host_config.maxport = 0;
 

--- a/scripts/installNuve.sh
+++ b/scripts/installNuve.sh
@@ -59,7 +59,7 @@ populate_mongo(){
   mkdir -p $ROOT/licode_config;
 
   if [ ! -f "$ROOT/licode_config/host.js" ]; then
-    cp $PATHNAME/default_host_config.js $ROOT/licode_config/host.js
+    cp $PATHNAME/host_default.js $ROOT/licode_config/host.js
   fi
 
 }

--- a/scripts/installNuve.sh
+++ b/scripts/installNuve.sh
@@ -54,6 +54,14 @@ populate_mongo(){
   replacement=s/_auto_generated_KEY_/${SERVKEY}/
   sed $replacement $BUILD_DIR/licode_1.js > $ROOT/licode_config.js
   rm $BUILD_DIR/licode_1.js
+
+  # Write network-config file
+  mkdir -p $ROOT/licode_config;
+
+  if [ ! -f "$ROOT/licode_config/host.js" ]; then
+    cp $PATHNAME/default_host_config.js $ROOT/licode_config/host.js
+  fi
+
 }
 
 install_nuve

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -1,4 +1,7 @@
-var config = {}
+var config = {};
+
+/* Read up host-specic network configuration */
+var network_config = require("./licode_config/host");
 
 /*********************************************************
  COMMON CONFIGURATION
@@ -15,8 +18,8 @@ config.logger.config_file = '../log4js_configuration.json'; //default value: "..
  It's used by Nuve and ErizoController
 **********************************************************/
 config.cloudProvider = {};
-config.cloudProvider.name = '';
-//In Amazon Ec2 instances you can specify the zone host. By default is 'ec2.us-east-1a.amazonaws.com' 
+config.cloudProvider.name = network_config.cloudProviderName;
+//In Amazon Ec2 instances you can specify the zone host. By default is 'ec2.us-east-1a.amazonaws.com'
 config.cloudProvider.host = '';
 config.cloudProvider.accessKey = '';
 config.cloudProvider.secretAccessKey = '';
@@ -35,21 +38,24 @@ config.nuve.testErizoController = 'localhost:8080'; // default value: 'localhost
 **********************************************************/
 config.erizoController = {};
 
-//Use undefined to run clients without Stun 
-config.erizoController.stunServerUrl = 'stun:stun.l.google.com:19302'; // default value: 'stun:stun.l.google.com:19302'
+config.erizoController.stunServerUrl = '';
 
 // Default and max video bandwidth parameters to be used by clients
 config.erizoController.defaultVideoBW = 300; //default value: 300
 config.erizoController.maxVideoBW = 300; //default value: 300
 
-// Public erizoController IP for websockets (useful when behind NATs)
-// Use '' to automatically get IP from the interface
-config.erizoController.publicIP = ''; //default value: ''
-// Use '' to use the public IP address instead of a hostname
-config.erizoController.hostname = ''; //default value: ''
+//Public erizoController IP for websockets (useful when behind NATs)
+//Use '' to automatically get IP from the interface
+config.erizoController.publicIP = network_config.publicIP;
+//Use '' to use the public IP address instead of a hostname
+config.erizoController.hostname = network_config.publicHostname;
 config.erizoController.port = 8080; //default value: 8080
 // Use true if clients communicate with erizoController over SSL
 config.erizoController.ssl = false; //default value: false
+
+// Not really necessary
+config.minervaHost = network_config.publicHostname;
+
 
 // Use the name of the inferface you want to bind to for websockets
 // config.erizoController.networkInterface = 'eth1' // default value: undefined
@@ -70,7 +76,7 @@ config.erizoController.roles =
     "viewer": {"subscribe": true},
     "viewerWithData": {"subscribe": true, "publish": {"audio": false, "video": false, "screen": false, "data": true}}}; // default value: {"presenter":{"publish": true, "subscribe":true, "record":true}, "viewer":{"subscribe":true}, "viewerWithData":{"subscribe":true, "publish":{"audio":false,"video":false,"screen":false,"data":true}}}
 
-// If true, erizoController sends stats to rabbitMQ queue "stats_handler" 
+// If true, erizoController sends stats to rabbitMQ queue "stats_handler"
 config.erizoController.sendStats = false; // default value: false
 
 // If undefined, the path will be /tmp/
@@ -82,7 +88,7 @@ config.erizoController.recording_path = undefined; // default value: undefined
 config.erizoAgent = {};
 
 // Max processes that ErizoAgent can run
-config.erizoAgent.maxProcesses 	  = 1; // default value: 1
+config.erizoAgent.maxProcesses    = 1; // default value: 1
 // Number of precesses that ErizoAgent runs when it starts. Always lower than or equals to maxProcesses.
 config.erizoAgent.prerunProcesses = 1; // default value: 1
 
@@ -97,8 +103,8 @@ config.erizo.stunserver = ''; // default value: ''
 config.erizo.stunport = 0; // default value: 0
 
 //note, this won't work with all versions of libnice. With 0 all the available ports are used
-config.erizo.minport = 0; // default value: 0
-config.erizo.maxport = 0; // default value: 0
+config.erizo.minport = network_config.minport;
+config.erizo.maxport = network_config.maxport;
 
 /***** END *****/
 // Following lines are always needed.

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -1,7 +1,7 @@
 var config = {};
 
 /* Read up host-specic network configuration */
-var network_config = require("./licode_config/host");
+var host_config = require("./licode_config/host");
 
 /*********************************************************
  COMMON CONFIGURATION
@@ -18,7 +18,7 @@ config.logger.config_file = '../log4js_configuration.json'; //default value: "..
  It's used by Nuve and ErizoController
 **********************************************************/
 config.cloudProvider = {};
-config.cloudProvider.name = network_config.cloudProviderName;
+config.cloudProvider.name = host_config.cloudProviderName;
 //In Amazon Ec2 instances you can specify the zone host. By default is 'ec2.us-east-1a.amazonaws.com'
 config.cloudProvider.host = '';
 config.cloudProvider.accessKey = '';
@@ -38,7 +38,8 @@ config.nuve.testErizoController = 'localhost:8080'; // default value: 'localhost
 **********************************************************/
 config.erizoController = {};
 
-config.erizoController.stunServerUrl = '';
+//Use undefined to run clients without Stun
+config.erizoController.stunServerUrl = 'stun:stun.l.google.com:19302'; // default value: 'stun:stun.l.google.com:19302'
 
 // Default and max video bandwidth parameters to be used by clients
 config.erizoController.defaultVideoBW = 300; //default value: 300
@@ -46,15 +47,15 @@ config.erizoController.maxVideoBW = 300; //default value: 300
 
 //Public erizoController IP for websockets (useful when behind NATs)
 //Use '' to automatically get IP from the interface
-config.erizoController.publicIP = network_config.publicIP;
+config.erizoController.publicIP = host_config.publicIP;
 //Use '' to use the public IP address instead of a hostname
-config.erizoController.hostname = network_config.publicHostname;
+config.erizoController.hostname = host_config.publicHostname;
 config.erizoController.port = 8080; //default value: 8080
 // Use true if clients communicate with erizoController over SSL
 config.erizoController.ssl = false; //default value: false
 
 // Not really necessary
-config.minervaHost = network_config.publicHostname;
+config.minervaHost = host_config.publicHostname;
 
 
 // Use the name of the inferface you want to bind to for websockets
@@ -103,8 +104,8 @@ config.erizo.stunserver = ''; // default value: ''
 config.erizo.stunport = 0; // default value: 0
 
 //note, this won't work with all versions of libnice. With 0 all the available ports are used
-config.erizo.minport = network_config.minport;
-config.erizo.maxport = network_config.maxport;
+config.erizo.minport = host_config.minport;
+config.erizo.maxport = host_config.maxport;
 
 /***** END *****/
 // Following lines are always needed.


### PR DESCRIPTION
This pull request is useful with automatic deployment scripts deploying to cloud providers.  It pulls all host-specific configuration, including public IP and host name, into a separate file called host.js.   This file can be overridden when a new licode box is deployed with just the information specific to that host.