### PR TITLE
Support desktopStreamId parameter in Erizo.Stream. 

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -79,14 +79,29 @@ Erizo.Stream = function (spec) {
         if ((spec.audio || spec.video || spec.screen) && spec.url === undefined) {
           L.Logger.debug("Requested access to local media");
           var videoOpt = spec.video;
-          if (videoOpt == true && that.videoSize !== undefined) {
+          if (videoOpt === true && that.videoSize !== undefined) {
             videoOpt = {mandatory: {minWidth: that.videoSize[0], minHeight: that.videoSize[1], maxWidth: that.videoSize[2], maxHeight: that.videoSize[3]}};
           }
-          var opt = {video: videoOpt, audio: spec.audio, fake: spec.fake, screen: spec.screen, extensionId:that.extensionId};
-          L.Logger.debug(opt);
-          Erizo.GetUserMedia(opt, function (stream) {
-            //navigator.webkitGetUserMedia("audio, video", function (stream) {
+          var opt = {video: videoOpt, audio: spec.audio, fake: spec.fake};
+          if (spec.screen) {
+            opt.video.mandatory.maxWidth = screen.availWidth;
+            opt.video.mandatory.maxheight = screen.availHeight;
 
+            // If desktopStreamId is passed in the spec, it means we used our our own Chrome extension
+            // to invoke the Media picker and get a desktopStreamId
+            if(spec.desktopStreamId) {
+                opt.video.mandatory.chromeMediaSource = 'desktop';
+                opt.video.mandatory.chromeMediaSourceId = spec.desktopStreamId;
+            }
+            // Otherwise, Erizo.GetUserMedia will invoke the Chrome extension
+            else {
+                opt.screen = spec.screen;
+                opt.extensionId = that.extensionId;
+            }
+          }
+
+          L.Logger.debug("Calling GetUserMedia with options", opt);
+          Erizo.GetUserMedia(opt, function (stream) {
             L.Logger.info("User has granted access to local media.");
             that.stream = stream;
 


### PR DESCRIPTION
At Minerva Project we have built our own screen sharing extension that we use for Licode and another WebRTC project.  This extension has it's own logic for communicating with the Chrome extension via passing messages on the window -- which is differs from the logic in Erizo.GetUserMedia.

The change in this pull request allows us to use our extension by simply passing the desktopStreamId parameter returned from our extension to the Erizo.Stream constructor.

Couple of other small changes in this pull request:  always set max width/height to the available screen width/height when sharing screens.  And we always set frame rate to 30.  Shared screens look awesome when we do this.

I'm submitting this as a pull in case other people have their own Chrome extensions, and so we don't have merge conflicts if this code evolves in the future.

