### PR TITLE
add support for altering the rabbitmq login/password

### DIFF
--- a/erizo_controller/common/rpc.js
+++ b/erizo_controller/common/rpc.js
@@ -10,6 +10,9 @@ GLOBAL.config.rabbit = GLOBAL.config.rabbit || {};
 GLOBAL.config.rabbit.host = GLOBAL.config.rabbit.host || 'localhost';
 GLOBAL.config.rabbit.port = GLOBAL.config.rabbit.port || 5672;
 
+GLOBAL.config.rabbit.login = GLOBAL.config.rabbit.login || 'guest';
+GLOBAL.config.rabbit.password = GLOBAL.config.rabbit.password || 'guest';
+
 var TIMEOUT = 5000;
 
 // This timeout shouldn't be too low because it won't listen to onReady responses from ErizoJS
@@ -30,6 +33,9 @@ if (GLOBAL.config.rabbit.url !== undefined) {
     addr.host = GLOBAL.config.rabbit.host;
     addr.port = GLOBAL.config.rabbit.port;
 }
+
+addr.login = GLOBAL.config.rabbit.login;
+addr.password = GLOBAL.config.rabbit.password;
 
 exports.setPublicRPC = function(methods) {
     rpcPublic = methods;

--- a/nuve/nuveAPI/rpc/rpc.js
+++ b/nuve/nuveAPI/rpc/rpc.js
@@ -13,6 +13,9 @@ config.rabbit = config.rabbit || {};
 config.rabbit.host = config.rabbit.host || 'localhost';
 config.rabbit.port = config.rabbit.port || 5672;
 
+config.rabbit.login = config.rabbit.login || 'guest';
+config.rabbit.password = config.rabbit.password || 'guest';
+
 var TIMEOUT = 3000;
 
 var corrID = 0;
@@ -30,6 +33,9 @@ if (config.rabbit.url !== undefined) {
     addr.host = config.rabbit.host;
     addr.port = config.rabbit.port;
 }
+
+addr.login = config.rabbit.login;
+addr.password = config.rabbit.password;
 
 exports.connect = function () {
 

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -7,6 +7,9 @@ var config = {}
 config.rabbit = {};
 config.rabbit.host = 'localhost'; //default value: 'localhost'
 config.rabbit.port = 5672; //default value: 5672
+config.rabbit.login = 'guest';
+config.rabbit.password = 'guest';
+
 config.logger = {};
 config.logger.config_file = '../log4js_configuration.json'; //default value: "../log4js_configuration.json"
 


### PR DESCRIPTION
RabbitMQ recommends deleting the guest account, or at least changing the password. https://www.rabbitmq.com/access-control.html

These changes add support for using a different rabbitmq account via the config file, I did not add any command line options.