### PR TITLE
asset URL should not be hard coded, use empty URL and host assets locall...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ extras/vagrant/.vagrant
 extras/vagrant/licode/
 erizo_controller/erizoAgent/out.log
 erizo_controller/erizoAgent/erizo-*.log
+.project
+.cproject

--- a/erizo_controller/erizoClient/src/views/View.js
+++ b/erizo_controller/erizoClient/src/views/View.js
@@ -11,6 +11,6 @@ Erizo.View = function (spec) {
     // Variables
 
     // URL where it will look for icons and assets
-    that.url = "http://chotis2.dit.upm.es:3000";
+    that.url = '';
     return that;
 };

--- a/scripts/installBasicExample.sh
+++ b/scripts/installBasicExample.sh
@@ -11,5 +11,7 @@ EXTRAS=$ROOT/extras
 
 cd $EXTRAS/basic_example
 
+cp -r ${ROOT}/erizo_controller/erizoClient/dist/assets public/
+
 npm install --loglevel error express body-parser morgan errorhandler
 cd $CURRENT_DIR


### PR DESCRIPTION
The asset URL is hard coded in erizo_controller/erizoClient/src/views/View.js.  This can be annoying if that site is offline or slow.  The assets are already included in the project and can (and probably should) be hosted locally, so here's the changes to do so.