### PR TITLE
Update openssl lib to 1.0.1j

### DIFF
--- a/scripts/installCentOsDeps.sh
+++ b/scripts/installCentOsDeps.sh
@@ -51,9 +51,9 @@ install_apt_deps(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -zxvf openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    curl -O http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+    tar -zxvf openssl-1.0.1j.tar.gz
+    cd openssl-1.0.1j
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0
     make install

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -36,9 +36,9 @@ install_brew_deps(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -zxvf openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    curl -O http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+    tar -zxvf openssl-1.0.1j.tar.gz
+    cd openssl-1.0.1j
     ./Configure --prefix=$PREFIX_DIR darwin64-x86_64-cc -fPIC
     make -s V=0
     make install

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -30,9 +30,9 @@ install_apt_deps(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1e.tar.gz
-    tar -zxvf openssl-1.0.1e.tar.gz > /dev/null 2> /dev/null
-    cd openssl-1.0.1e
+    curl -O http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+    tar -zxvf openssl-1.0.1j.tar.gz > /dev/null 2> /dev/null
+    cd openssl-1.0.1j
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0
     make install

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -56,9 +56,9 @@ install_apt_deps(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -zxvf openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    curl -O http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+    tar -zxvf openssl-1.0.1j.tar.gz
+    cd openssl-1.0.1j
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0
     make install

--- a/scripts/installUbuntuDepsUnattended.sh
+++ b/scripts/installUbuntuDepsUnattended.sh
@@ -57,9 +57,9 @@ install_apt_deps(){
 install_openssl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O http://www.openssl.org/source/openssl-1.0.1g.tar.gz
-    tar -zxvf openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    curl -O http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+    tar -zxvf openssl-1.0.1j.tar.gz
+    cd openssl-1.0.1j
     ./config --prefix=$PREFIX_DIR -fPIC
     make -s V=0
     make install


### PR DESCRIPTION
Updated scripts to download the new openssl 1.0.1 version since http://www.openssl.org/source/openssl-1.0.1g.tar.gz was giving 404 errors