### PR TITLE
Add TURN support for Firefox

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -19,6 +19,10 @@ Erizo.FirefoxStack = function (spec) {
         that.pc_config.iceServers.push({"url": spec.stunServerUrl});
     } 
 
+    if ((spec.turnServer || {}).url) {
+        that.pc_config.iceServers.push({"username": spec.turnServer.username, "credential": spec.turnServer.password, "url": spec.turnServer.url});
+    }
+
     if (spec.audio === undefined) {
         spec.audio = true;
     }
@@ -35,7 +39,7 @@ Erizo.FirefoxStack = function (spec) {
 
     that.roapSessionId = 103;
 
-    that.peerConnection = new WebkitRTCPeerConnection();
+    that.peerConnection = new WebkitRTCPeerConnection(that.pc_config, that.con);
 
     that.peerConnection.onicecandidate = function (event) {
         L.Logger.debug("PeerConnection: ", spec.session_id);


### PR DESCRIPTION
Firefox supports TURN, but Licode doesn't pass the TURN url.

I tested the change by running Licode on a remote server and adding a firewall rule to my machine to block outgoing IP packets from my machine to the remote Licode server, therefore forcing TURN.

The result of the test shows the following in about:webrtc (after this change - before, all candidates would fail):

    Local candidate			 				Remote candidate
    192.168.1.100:64140/udp(host)			10.176.5.159:41655/udp(host)   inprogress		
    192.168.1.100:64140/udp(host)			REMOTE_IP:36724/udp(host)   failed		
    TURN_ADD:64016/udp(relayed-udp)		 10.176.5.159:41655/udp(host)   inprogress		
    TURN_ADD:64016/udp(relayed-udp)		 REMOTE_IP:36724/udp(host)   succeeded  *  *
