### PR TITLE
Set our remote credentials on our nice agent when we first receive an SD...

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -75,7 +75,7 @@ void Resender::resend(const boost::system::error_code& ec) {
 }
 
 DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, bool bundle, bool rtcp_mux, TransportListener *transportListener, 
-    const std::string &stunServer, int stunPort, int minPort, int maxPort):
+    const std::string &stunServer, int stunPort, int minPort, int maxPort, std::string username, std::string password):
   Transport(med, transport_name, bundle, rtcp_mux, transportListener, stunServer, stunPort, minPort, maxPort), 
   readyRtp(false), readyRtcp(false), running_(false) {
   ELOG_DEBUG( "Initializing DtlsTransport" );
@@ -96,7 +96,7 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, b
     (new DtlsFactory())->createClient(dtlsRtcp);
     dtlsRtcp->setDtlsReceiver(this);
   }
-  nice_.reset(new NiceConnection(med, transport_name, this, comps, stunServer, stunPort, minPort, maxPort));
+  nice_.reset(new NiceConnection(med, transport_name, this, comps, stunServer, stunPort, minPort, maxPort, username, password));
   running_ =true;
   getNice_Thread_ = boost::thread(&DtlsTransport::getNiceDataLoop, this);
 

--- a/erizo/src/erizo/DtlsTransport.h
+++ b/erizo/src/erizo/DtlsTransport.h
@@ -16,7 +16,7 @@ namespace erizo {
   class DtlsTransport : dtls::DtlsReceiver, public Transport {
     DECLARE_LOGGER();
     public:
-    DtlsTransport(MediaType med, const std::string &transport_name, bool bundle, bool rtcp_mux, TransportListener *transportListener, const std::string &stunServer, int stunPort, int minPort, int maxPort);
+    DtlsTransport(MediaType med, const std::string &transport_name, bool bundle, bool rtcp_mux, TransportListener *transportListener, const std::string &stunServer, int stunPort, int minPort, int maxPort, std::string username, std::string password);
     virtual ~DtlsTransport();
     void connectionStateChanged(IceState newState);
     std::string getMyFingerprint();

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -76,7 +76,7 @@ namespace erizo {
   }
 
   NiceConnection::NiceConnection(MediaType med, const std::string &transport_name,NiceConnectionListener* listener, 
-      unsigned int iceComponents, const std::string& stunServer, int stunPort, int minPort, int maxPort)
+      unsigned int iceComponents, const std::string& stunServer, int stunPort, int minPort, int maxPort, std::string username, std::string password)
      : mediaType(med), agent_(NULL), listener_(listener), candsDelivered_(0), context_(NULL), iceState_(NICE_INITIAL), iceComponents_(iceComponents),
              stunServer_(stunServer), stunPort_ (stunPort), minPort_(minPort), maxPort_(maxPort) {
 
@@ -134,8 +134,11 @@ namespace erizo {
     nice_agent_get_local_credentials(agent_, 1, &ufrag, &upass);
     ufrag_ = std::string(ufrag);
     upass_ = std::string(upass);
+
+    // Set our remote credentials.  This must be done *after* we add a stream.
+    nice_agent_set_remote_credentials(agent_, (guint) 1, username.c_str(), password.c_str());
+
     // Set Port Range ----> If this doesn't work when linking the file libnice.sym has to be modified to include this call
-    
     if (minPort_!=0 && maxPort_!=0){
       ELOG_DEBUG("Setting port range: %d to %d\n", minPort_, maxPort_);
       nice_agent_set_port_range(agent_, (guint)1, (guint)1, (guint)minPort_, (guint)maxPort_);

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -81,7 +81,7 @@ public:
    * @param iceComponents Number of ice components pero connection. Default is 1 (rtcp-mux).
 	 */
 	NiceConnection(MediaType med, const std::string &transportName, NiceConnectionListener* listener, unsigned int iceComponents=1,
-		const std::string& stunServer = "", int stunPort = 3478, int minPort = 0, int maxPort = 65535);
+		const std::string& stunServer = "", int stunPort = 3478, int minPort = 0, int maxPort = 65535, std::string username = "", std::string password = "");
 
 	virtual ~NiceConnection();
 	/**

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -67,7 +67,6 @@ namespace erizo {
   bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
     ELOG_DEBUG("Set Remote SDP %s", sdp.c_str());
     remoteSdp_.initWithSdp(sdp, "");
-    //std::vector<CryptoInfo> crypto_remote = remoteSdp_.getCryptoInfos();
 
     bundle_ = remoteSdp_.isBundle;
     ELOG_DEBUG("Is bundle? %d %d ", bundle_, true);
@@ -89,12 +88,15 @@ namespace erizo {
 
     if (remoteSdp_.profile == SAVPF) {
       if (remoteSdp_.isFingerprint) {
-        // DTLS-SRTP
         if (remoteSdp_.hasVideo||bundle_) {
-          videoTransport_ = new DtlsTransport(VIDEO_TYPE, "video", bundle_, remoteSdp_.isRtcpMux, this, stunServer_, stunPort_, minPort_, maxPort_);
+          std::string username, password;
+          remoteSdp_.getCredentials(username, password, VIDEO_TYPE);
+          videoTransport_ = new DtlsTransport(VIDEO_TYPE, "video", bundle_, remoteSdp_.isRtcpMux, this, stunServer_, stunPort_, minPort_, maxPort_, username, password);
         }
         if (!bundle_ && remoteSdp_.hasAudio) {
-          audioTransport_ = new DtlsTransport(AUDIO_TYPE, "audio", bundle_, remoteSdp_.isRtcpMux, this, stunServer_, stunPort_, minPort_, maxPort_);
+          std::string username, password;
+          remoteSdp_.getCredentials(username, password, AUDIO_TYPE);
+          audioTransport_ = new DtlsTransport(AUDIO_TYPE, "audio", bundle_, remoteSdp_.isRtcpMux, this, stunServer_, stunPort_, minPort_, maxPort_, username, password);
         }
       }
     }


### PR DESCRIPTION
...P offer. This resolves a race condition where stun signalling happens faster than our HTTPS signaling over socket-io, and a candidate pair is created with no credentials (and thus fails)