### PR TITLE
Fix build with boost-1.57

### DIFF
--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <queue>
 #include <boost/thread.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include "MediaDefinitions.h"
 #include "SdpInfo.h"

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -8,6 +8,7 @@
 #include "codecs/VideoCodec.h"
 #include "MediaProcessor.h"
 #include "boost/thread.hpp"
+#include "boost/scoped_ptr.hpp"
 #include "logger.h"
 
 extern "C" {

--- a/erizo/src/erizo/rtp/RtpSink.h
+++ b/erizo/src/erizo/rtp/RtpSink.h
@@ -11,6 +11,7 @@
 #include <boost/asio.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <queue>
 
 #include "../MediaDefinitions.h"

--- a/erizo/src/erizo/rtp/RtpSource.h
+++ b/erizo/src/erizo/rtp/RtpSource.h
@@ -11,6 +11,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
+#include <boost/scoped_ptr.hpp>
 #include "../MediaDefinitions.h"
 #include "../logger.h"
 


### PR DESCRIPTION
Because boost/scoped_ptr.hpp is no more included by boost/thread.hpp through boost/future.hpp.

See http://www.boost.org/doc/libs/1_57_0/boost/thread/future.hpp

