### PR TITLE
Run ErizoController via HTTPS - fixes #81

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -3,8 +3,8 @@ var crypto = require('crypto');
 var rpcPublic = require('./rpc/rpcPublic');
 var ST = require('./Stream');
 var http = require('http');
-var server = http.createServer();
-var io = require('socket.io').listen(server, {log:false});
+var https = require('https');
+var fs = require("fs");
 var config = require('./../../licode_config');
 var Permission = require('./permission');
 var Getopt = require('node-getopt');
@@ -91,7 +91,24 @@ var controller = require('./roomController');
 // Logger
 var log = logger.getLogger("ErizoController");
 
-server.listen(8080);
+// Instantiate the server
+if(GLOBAL.config.erizoController.ssl){
+    if(!GLOBAL.config.erizoController.sslKey || !GLOBAL.config.erizoController.sslCert)
+        log.warn('SSL key and certification needs to be provided in licode_config as sslKey & sslCert');
+        var server = http.createServer();
+    else{
+        var options = {
+            key: fs.readFileSync(GLOBAL.config.erizoController.sslKey).toString(),
+            cert: fs.readFileSync(GLOBAL.config.erizoController.sslCert).toString()
+        };
+        var server = https.createServer(options);
+    }
+}
+else
+    var server = http.createServer();
+
+server.listen(GLOBAL.config.erizoController.port);
+var io = require('socket.io').listen(server, {log:false});
 
 io.set('log level', 0);
 

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -47,9 +47,13 @@ config.erizoController.maxVideoBW = 300; //default value: 300
 config.erizoController.publicIP = ''; //default value: ''
 // Use '' to use the public IP address instead of a hostname
 config.erizoController.hostname = ''; //default value: ''
+// Use 443 if clients communicate with erizoController over SSL
 config.erizoController.port = 8080; //default value: 8080
 // Use true if clients communicate with erizoController over SSL
 config.erizoController.ssl = false; //default value: false
+
+config.erizoController.sslKey = ''; // SSL Key file . e.g: /etc/httpd/certs/domain_server.key
+config.erizoController.sslCert = ''; // SSL Certification file . e.g: /etc/httpd/certs/domain_server.crt
 
 // Use the name of the inferface you want to bind to for websockets
 // config.erizoController.networkInterface = 'eth1' // default value: undefined


### PR DESCRIPTION
Since the port was hardcoded ( 'server.listen(8080);' ) and ssl doesn't worked with http server(It needs https server), couple of changes applied to fix these issues.
@jcague 