### PR TITLE
RTC objects no longer act as POJSOs.

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -83,10 +83,16 @@ Erizo.ChromeStableStack = function (spec) {
                 event.candidate.candidate ="a="+event.candidate.candidate;
             };
 
+            var candidateObject = {
+                sdpMLineIndex: event.candidate.sdpMLineIndex,
+                sdpMid: event.candidate.sdpMid,
+                candidate: event.candidate.candidate
+            };
+
             if (spec.remoteDescriptionSet) {
-                spec.callback({type:'candidate', candidate: event.candidate});
+                spec.callback({type:'candidate', candidate: candidateObject});
             } else {
-                spec.localCandidates.push(event.candidate);
+                spec.localCandidates.push(candidateObject);
                 console.log("Local Candidates stored: ", spec.localCandidates.length, spec.localCandidates);
             }
 
@@ -112,7 +118,10 @@ Erizo.ChromeStableStack = function (spec) {
     var setLocalDesc = function (sessionDescription) {
         sessionDescription.sdp = setMaxBW(sessionDescription.sdp);
         sessionDescription.sdp = sessionDescription.sdp.replace(/a=ice-options:google-ice\r\n/g, "");
-        spec.callback(sessionDescription);
+        spec.callback({
+            type: sessionDescription.type,
+            sdp: sessionDescription.sdp
+        });
         localDesc = sessionDescription;
         //that.peerConnection.setLocalDescription(sessionDescription);
     }
@@ -120,7 +129,10 @@ Erizo.ChromeStableStack = function (spec) {
     var setLocalDescp2p = function (sessionDescription) {
         sessionDescription.sdp = setMaxBW(sessionDescription.sdp);
         sessionDescription.sdp = sessionDescription.sdp.replace(/a=ice-options:google-ice\r\n/g, "");
-        spec.callback(sessionDescription);
+        spec.callback({
+            type: sessionDescription.type,
+            sdp: sessionDescription.sdp
+        });
         localDesc = sessionDescription;
         that.peerConnection.setLocalDescription(sessionDescription);
     }


### PR DESCRIPTION
As of Chrome 43, JSON.stringify no long works on RTCSessionDescription
and RTCIceCandidate objects and we need to expand them manually for
signaling. This change tested on Chrome 41 and Chrome 43.

Upstream bug: https://code.google.com/p/chromium/issues/detail?id=467471