### PR TITLE
Fix build errors on Mac Yosemite

### DIFF
--- a/erizo/src/erizo/DtlsTransport.h
+++ b/erizo/src/erizo/DtlsTransport.h
@@ -5,6 +5,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio.hpp>
+#include <boost/scoped_ptr.hpp>
 #include "dtls/DtlsSocket.h"
 #include "NiceConnection.h"
 #include "Transport.h"

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <queue>
+#include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 
 #include "MediaDefinitions.h"

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -736,7 +736,7 @@ namespace erizo {
   int SdpInfo::getAudioInternalPT(int externalPT) {
       // should use separate mapping for video and audio at the very least
       // standard requires separate mappings for each media, even!
-      std::map<const int, int>::iterator found = outInPTMap.find(externalPT);
+      std::map<int, int>::iterator found = outInPTMap.find(externalPT);
       if (found != outInPTMap.end()) {
           return found->second;
       }
@@ -753,7 +753,7 @@ namespace erizo {
   int SdpInfo::getAudioExternalPT(int internalPT) {
     // should use separate mapping for video and audio at the very least
     // standard requires separate mappings for each media, even!
-    std::map<const int, int>::iterator found = inOutPTMap.find(internalPT);
+    std::map<int, int>::iterator found = inOutPTMap.find(internalPT);
     if (found != inOutPTMap.end()) {
         return found->second;
     }

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -215,11 +215,11 @@ public:
     /**
     * Mapping from internal PT (key) to external PT (value)
     */
-    std::map<const int, int> inOutPTMap;
+    std::map<int, int> inOutPTMap;
     /**
     * Mapping from external PT (key) to intermal PT (value)
     */
-    std::map<const int, int> outInPTMap;
+    std::map<int, int> outInPTMap;
     /**
      * The negotiated payload list
      */

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -1,6 +1,7 @@
 #ifndef EXTERNALINPUT_H_
 #define EXTERNALINPUT_H_
 
+#include <boost/scoped_ptr.hpp>
 #include <string> 
 #include <map>
 #include <queue>

--- a/erizo/src/erizo/rtp/RtpSink.h
+++ b/erizo/src/erizo/rtp/RtpSink.h
@@ -9,6 +9,7 @@
 #define RTPSINK_H_
 
 #include <boost/asio.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread.hpp>
 #include <queue>

--- a/erizo/src/erizo/rtp/RtpSource.h
+++ b/erizo/src/erizo/rtp/RtpSource.h
@@ -10,6 +10,7 @@
 #define RTPSOURCE_H_
 
 #include <boost/asio.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 #include "../MediaDefinitions.h"
 #include "../logger.h"


### PR DESCRIPTION
1. error: no template named 'scoped_ptr' in namespace 'boost'; did you
mean 'boost::asio::detail::scoped_ptr'
2. /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:294:15:
error: read-only variable is not assignable