### PR TITLE
missing space in a=fmtp opus line

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -331,9 +331,9 @@ namespace erizo {
           for (std::map<std::string, std::string>::const_iterator theIt = rtp.formatParameters.begin(); 
               theIt != rtp.formatParameters.end(); theIt++){
             if (theIt->first.compare("none")){
-              sdp << "a=fmtp:" << payloadType << theIt->first << "=" << theIt->second << endl;
+              sdp << "a=fmtp:" << payloadType << " " << theIt->first << "=" << theIt->second << endl;
             }else{
-              sdp << "a=fmtp:" << payloadType << theIt->second << endl;
+              sdp << "a=fmtp:" << payloadType << " " << theIt->second << endl;
             }
         
           }


### PR DESCRIPTION
For OPUS at least, the a=fmtp line looked like:
a=fmtp:111minptime=10

it lacks a space after the Codec number, and should look like:
a=fmtp:111 minptime=10
