### PR TITLE
This fixes exception in setMaxBW when doing p2p audio only call

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BowserStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BowserStack.js
@@ -45,8 +45,10 @@ Erizo.BowserStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=video.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         if (spec.maxAudioBW) {
@@ -54,8 +56,10 @@ Erizo.BowserStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=audio.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         return sdp;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeCanaryStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeCanaryStack.js
@@ -66,14 +66,18 @@ Erizo.ChromeCanaryStack = function (spec) {
     var setMaxBW = function (sdp) {
         if (spec.maxVideoBW) {
             var a = sdp.match(/m=video.*\r\n/);
-            var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         if (spec.maxAudioBW) {
             var a = sdp.match(/m=audio.*\r\n/);
-            var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         return sdp;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeRoapStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeRoapStack.js
@@ -66,14 +66,18 @@ Erizo.ChromeRoapStack = function (spec) {
     var setMaxBW = function (sdp) {
         if (spec.maxVideoBW) {
             var a = sdp.match(/m=video.*\r\n/);
-            var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         if (spec.maxAudioBW) {
             var a = sdp.match(/m=audio.*\r\n/);
-            var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         return sdp;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -50,8 +50,10 @@ Erizo.ChromeStableStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=video.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         if (spec.audio && spec.maxAudioBW) {
@@ -59,8 +61,10 @@ Erizo.ChromeStableStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=audio.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         return sdp;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -82,8 +82,10 @@ Erizo.FirefoxStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=video.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         if (spec.audio && spec.maxAudioBW) {
@@ -91,8 +93,10 @@ Erizo.FirefoxStack = function (spec) {
             if (a == null){
               a = sdp.match(/m=audio.*\n/);
             }
-            var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
-            sdp = sdp.replace(a[0], r);
+            if (a && (a.length > 0)) {
+                var r = a[0] + "b=AS:" + spec.maxAudioBW + "\r\n";
+                sdp = sdp.replace(a[0], r);
+            }
         }
 
         return sdp;


### PR DESCRIPTION
When doing p2p audio only call, `spec.video` is undefined and gets set to true:

    if (spec.video === undefined) {
        spec.video = true;
    }

This causes a crash in `setMaxBW` because sdp does not contain `m=video` media stream line.

    var a = sdp.match(/m=video.*\r\n/);
    if (a == null){
        a = sdp.match(/m=video.*\n/);
    }
    // a is still null because sdp does not contain "m=video" line
    var r = a[0] + "b=AS:" + spec.maxVideoBW + "\r\n";
    sdp = sdp.replace(a[0], r);