### PR TITLE
Update Homebrew installation URL for Mac dependency script because it has moved

### DIFF
--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -25,7 +25,7 @@ parse_arguments(){
 }
 
 install_homebrew(){
-  ruby -e "$(curl -fsSkL raw.github.com/mxcl/homebrew/go/install)"
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 }
 
 install_brew_deps(){


### PR DESCRIPTION
Fix for this warning:
```
Installing homebrew... [press Enter]
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
```