### PR TITLE
fix for npm warnings regarding license and repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "licode",
   "version": "0.1.0",
   "description": "Open Source Communication Provider",
+  "license": "MIT",
+  "private": true,
   "devDependencies": {
     "vows": "0.6.x",
     "coffee-script": "1.4.x",


### PR DESCRIPTION
$ npm install
npm WARN package.json licode@0.1.0 No repository field.
npm WARN package.json licode@0.1.0 No license field.

license was set to 'MIT' and the package was marked private to eliminate warnings from npm