### PR TITLE
Erizo Controller policy fix

### DIFF
--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -67,8 +67,14 @@ for (var prop in opt.options) {
 var logger = require('./../common/logger').logger;
 var amqper = require('./../common/amqper');
 
+var getErizoAgent = undefined;
+if (config.erizoController.cloudHandlerPolicy) {
+	getErizoAgent = require('./../erizoController/ch_policies/' + config.erizoController.cloudHandlerPolicy).getErizoAgent;
+} 
+var agent_queue = getErizoAgent!=undefined ? getErizoAgent() : "ErizoAgent"; 
+
 // Logger
-var log = logger.getLogger("ErizoAgent");
+var log = logger.getLogger(agent_queue);
 
 var childs = [];
 
@@ -228,7 +234,7 @@ amqper.connect(function () {
     "use strict";
 
     amqper.setPublicRPC(api);
-    amqper.bind("ErizoAgent");
+    amqper.bind(agent_queue);
     amqper.bind("ErizoAgent_" + my_erizo_agent_id);
     amqper.bind_broadcast("ErizoAgent", function (m) {
         log.warn('No method defined');

--- a/erizo_controller/erizoController/ecch.js
+++ b/erizo_controller/erizoController/ecch.js
@@ -63,14 +63,12 @@ exports.Ecch = function (spec) {
 	    getErizoAgent = require('./ch_policies/' + config.erizoController.cloudHandlerPolicy).getErizoAgent;
 	}
 
+	var agent_queue = 'ErizoAgent';
+	if (getErizoAgent) {
+		agent_queue = getErizoAgent(agents);
+	}
+
 	that.getErizoJS = function(callback) {
-
-		var agent_queue = 'ErizoAgent';
-
-		if (getErizoAgent) {
-			agent_queue = getErizoAgent(agents);
-		}
-
 		log.info('Asking erizoJS to agent ', agent_queue);
 
 		amqper.callRpc(agent_queue, 'createErizoJS', [], {callback: function(erizo_id) {
@@ -100,8 +98,10 @@ exports.Ecch = function (spec) {
 	    }});
 	};
 
+	// TODO probably use agent_queue and try_again method
 	that.deleteErizoJS = function(erizo_id) {
-        amqper.broadcast("ErizoAgent", {method: "deleteErizoJS", args: [erizo_id]}, function(){}); 
+		//amqper.broadcast(agent_queue, {method: "deleteErizoJS", args: [erizo_id]}, function(){});
+		amqper.broadcast('ErizoAgent', {method: "deleteErizoJS", args: [erizo_id]}, function(){});
 	};
 
 	return that;


### PR DESCRIPTION
Erizo Controller policy always use "ErizoAgent" message queue since bind is hardcoded as amqper.bind("ErizoAgent"); and no value from getErizoAgent method is used.
Should be method getErizoAgent used also for deleteErizoJS?