### PR TITLE
Fix roomController::removeSubscriptions so that subscribers no longer…

### DIFF
--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -383,7 +383,13 @@ exports.RoomController = function (spec) {
 
         for (publisher_id in subscribers) {
             if (subscribers.hasOwnProperty(publisher_id)) {
-                index = subscribers[publisher_id].indexOf(subscriber_id);
+                index = -1;
+                for (var i=0; i < subscribers[publisher_id].length; i++) {
+                    if (subscribers[publisher_id][i].id === subscriber_id) {
+                        index = i;
+                        break;
+                    }
+                }
                 if (index !== -1) {
                     log.info('Removing subscriber ', subscriber_id, 'to muxer ', publisher_id);
 


### PR DESCRIPTION
… receive stream bits after disconnecting

This appears to be a simple coding bug, where elements of an array were assumed to be strings when they are really dictionaries. The result of this bug is that a client that subscribes to a stream continues to receive bits for that stream even after she disconnects.

See https://groups.google.com/forum/#!topic/lynckia/1Je8jj-5wUo