### PR TITLE
custom location for SSL creds

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -16,6 +16,8 @@ GLOBAL.config.erizoController.publicIP = GLOBAL.config.erizoController.publicIP 
 GLOBAL.config.erizoController.hostname = GLOBAL.config.erizoController.hostname|| '';
 GLOBAL.config.erizoController.port = GLOBAL.config.erizoController.port || 8080;
 GLOBAL.config.erizoController.ssl = GLOBAL.config.erizoController.ssl || false;
+GLOBAL.config.erizoController.ssl_key = GLOBAL.config.erizoController.ssl_key || '../../cert/key.pem';
+GLOBAL.config.erizoController.ssl_cert = GLOBAL.config.erizoController.ssl_cert || '../../cert/cert.pem';
 GLOBAL.config.erizoController.listen_port = GLOBAL.config.erizoController.listen_port || 8080;
 GLOBAL.config.erizoController.listen_ssl = GLOBAL.config.erizoController.listen_ssl || false;
 GLOBAL.config.erizoController.turnServer = GLOBAL.config.erizoController.turnServer || undefined;
@@ -96,8 +98,8 @@ if (GLOBAL.config.erizoController.listen_ssl) {
     var https = require('https');
     var fs = require('fs');
     var options = {
-        key: fs.readFileSync('../../cert/key.pem').toString(),
-        cert: fs.readFileSync('../../cert/cert.pem').toString()
+        key: fs.readFileSync(config.erizoController.ssl_key).toString(),
+        cert: fs.readFileSync(config.erizoController.ssl_cert).toString()
     };
     server = https.createServer(options);
 } else {

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -71,9 +71,13 @@ config.erizoController.port = 8080; //default value: 8080
 config.erizoController.ssl = false; //default value: false
 
 // This configuration is used by erizoController server to listen for connections
-// Use true if erizoController listens in HTTPS. SSL certificates located in /cert
+// Use true if erizoController listens in HTTPS.
 config.erizoController.listen_ssl = false; //default value: false
 config.erizoController.listen_port = 8080; //default value: 8080
+
+// Custom location for SSL certificates. Default located in /cert
+//config.erizoController.ssl_key = '/full/path/to/ssl.key';
+//config.erizoController.ssl_cert = '/full/path/to/ssl.crt';
 
 // Use the name of the inferface you want to bind to for websockets
 // config.erizoController.networkInterface = 'eth1' // default value: undefined


### PR DESCRIPTION
adds the following keys to licode_config.js
 - config.erizoController.ssl_key
 - config.erizoController.ssl_cert

allows specifying a custom location for SSL key/cert