### PR TITLE
provide config.erizoAgent.instanceLogDir

### DIFF
--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -11,6 +11,7 @@ GLOBAL.config.erizoAgent = GLOBAL.config.erizoAgent || {};
 GLOBAL.config.erizoAgent.maxProcesses = GLOBAL.config.erizoAgent.maxProcesses || 1;
 GLOBAL.config.erizoAgent.prerunProcesses = GLOBAL.config.erizoAgent.prerunProcesses === undefined ? 1 : GLOBAL.config.erizoAgent.prerunProcesses;
 GLOBAL.config.erizoAgent.publicIP = GLOBAL.config.erizoAgent.publicIP || '';
+GLOBAL.config.erizoAgent.instanceLogDir = GLOBAL.config.erizoAgent.instanceLogDir || '.';
 
 var BINDED_INTERFACE_NAME = GLOBAL.config.erizoAgent.networkInterface;
 
@@ -106,8 +107,8 @@ var launchErizoJS = function() {
     log.info("Launching a new ErizoJS process");
     var id = guid();
     var fs = require('fs');
-    var out = fs.openSync('./erizo-' + id + '.log', 'a');
-    var err = fs.openSync('./erizo-' + id + '.log', 'a');
+    var out = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');
+    var err = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');
     var erizoProcess = spawn('./launch.sh', ['./../erizoJS/erizoJS.js', id, privateIP, publicIP], { detached: true, stdio: [ 'ignore', out, err ] });
     erizoProcess.unref();
     erizoProcess.on('close', function (code) {

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -116,6 +116,8 @@ config.erizoAgent.prerunProcesses = 1; // default value: 1
 config.erizoAgent.publicIP = ''; //default value: ''
 // Use the name of the inferface you want to bind for ICE candidates
 // config.erizoAgent.networkInterface = 'eth1' // default value: undefined
+// Custom log directory for agent instance log files.
+// config.erizoAgent.instanceLogDir = '/path/to/dir';
 
 /*********************************************************
  ERIZO JS CONFIGURATION


### PR DESCRIPTION
Used to declare the log file location for spawned erizo instances.
Allows erizoAgent to more easily be run as non-root user.