### PR TITLE
Provide valid ID for local stream

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -31,7 +31,15 @@ Erizo.Stream = function (spec) {
     // Public functions
 
     that.getID = function () {
-        return spec.streamID;
+        var id;
+        // Unpublished local streams don't yet have an ID.
+        if (that.local && !spec.streamID) {
+            id = 'local';
+        }
+        else {
+            id = spec.streamID;
+        }
+        return id;
     };
 
     // Get attributes of this stream.


### PR DESCRIPTION
Local streams currently get an undefined ID in getID().