### PR TITLE
add label/bar options for showing streams.

### DIFF
--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -80,14 +80,20 @@ Erizo.AudioPlayer = function (spec) {
         that.div.appendChild(that.audio);
 
         // Bottom Bar
-        that.bar = new Erizo.Bar({elementID: 'player_' + that.id,
-                                  id: that.id,
-                                  stream: spec.stream,
-                                  media: that.audio,
-                                  options: spec.options});
+        if (spec.options.bar !== false) {
+            that.bar = new Erizo.Bar({elementID: 'player_' + that.id,
+                                      id: that.id,
+                                      stream: spec.stream,
+                                      media: that.audio,
+                                      options: spec.options});
 
-        that.div.onmouseover = onmouseover;
-        that.div.onmouseout = onmouseout;
+            that.div.onmouseover = onmouseover;
+            that.div.onmouseout = onmouseout;
+        }
+        else {
+            // Expose a consistent object to manipulate the media.
+            that.media = that.audio;
+        }
 
     } else {
         // It will stop the AudioPlayer and remove it from the HTML

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -152,14 +152,20 @@ Erizo.VideoPlayer = function (spec) {
     that.resize();
 
     // Bottom Bar
-    that.bar = new Erizo.Bar({elementID: 'player_' + that.id,
-                              id: that.id,
-                              stream: spec.stream,
-                              media: that.video,
-                              options: spec.options});
+    if (spec.options.bar !== false) {
+        that.bar = new Erizo.Bar({elementID: 'player_' + that.id,
+                                  id: that.id,
+                                  stream: spec.stream,
+                                  media: that.video,
+                                  options: spec.options});
 
-    that.div.onmouseover = onmouseover;
-    that.div.onmouseout = onmouseout;
+        that.div.onmouseover = onmouseover;
+        that.div.onmouseout = onmouseout;
+    }
+    else {
+        // Expose a consistent object to manipulate the media.
+        that.media = that.video;
+    }
 
     that.video.src = that.streamUrl;
 


### PR DESCRIPTION
This adds a 'label' and 'bar' key to the options arg for Erizo.Stream.show()

This allows:
- The same stream to be placed in multiple elements on the page using a
  custom label for each invocation of stream.show(), eg {label: 'foo'}
- The bottom bar to not be rendered if {bar: false} is passed. In this
  case, a 'media' prop is set on the stream object, to provide a
  consistent interface to the underlying audio or video object.

It does create the side effect of multiple independent bar controls
