### PR TITLE
allow DOM node to be passed to show/play method

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -196,11 +196,12 @@ Erizo.Stream = function (spec) {
                 top = parseInt(style.getPropertyValue('top'), 10);
 
             var div;
-            if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
+            if (typeof that.elementID === 'object' &&
+              typeof that.elementID.appendChild === 'function') {
                 div = that.elementID;
             }
             else {
-                div = document.getElementById(that.elementID),
+                div = document.getElementById(that.elementID);
             }
 
             var divStyle = document.defaultView.getComputedStyle(div),

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -193,10 +193,17 @@ Erizo.Stream = function (spec) {
                 width = parseInt(style.getPropertyValue('width'), 10),
                 height = parseInt(style.getPropertyValue('height'), 10),
                 left = parseInt(style.getPropertyValue('left'), 10),
-                top = parseInt(style.getPropertyValue('top'), 10),
+                top = parseInt(style.getPropertyValue('top'), 10);
 
+            var div;
+            if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
+                div = that.elementID;
+            }
+            else {
                 div = document.getElementById(that.elementID),
-                divStyle = document.defaultView.getComputedStyle(div),
+            }
+
+            var divStyle = document.defaultView.getComputedStyle(div),
                 divWidth = parseInt(divStyle.getPropertyValue('width'), 10),
                 divHeight = parseInt(divStyle.getPropertyValue('height'), 10),
 

--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -65,8 +65,14 @@ Erizo.AudioPlayer = function (spec) {
         that.div.setAttribute('style', 'width: 100%; height: 100%; position: relative; ' +
                               'overflow: hidden;');
 
-        document.getElementById(that.elementID).appendChild(that.div);
-        that.container = document.getElementById(that.elementID);
+        // Check for a passed DOM node.
+        if (typeof that.elementID == 'object' && typeof that.elementID.appendChild == 'function') {
+            that.container = that.elementID;
+        }
+        else {
+            that.container = document.getElementById(that.elementID);
+        }
+        that.container.appendChild(that.div);
 
         that.parentNode = that.div.parentNode;
 

--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -66,7 +66,8 @@ Erizo.AudioPlayer = function (spec) {
                               'overflow: hidden;');
 
         // Check for a passed DOM node.
-        if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
+        if (typeof that.elementID === 'object' &&
+          typeof that.elementID.appendChild === 'function') {
             that.container = that.elementID;
         }
         else {

--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -66,7 +66,7 @@ Erizo.AudioPlayer = function (spec) {
                               'overflow: hidden;');
 
         // Check for a passed DOM node.
-        if (typeof that.elementID == 'object' && typeof that.elementID.appendChild == 'function') {
+        if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
             that.container = that.elementID;
         }
         else {

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -127,7 +127,8 @@ Erizo.VideoPlayer = function (spec) {
 
     if (that.elementID !== undefined) {
         // Check for a passed DOM node.
-        if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
+        if (typeof that.elementID === 'object' &&
+          typeof that.elementID.appendChild === 'function') {
             that.container = that.elementID;
         }
         else {

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -127,7 +127,7 @@ Erizo.VideoPlayer = function (spec) {
 
     if (that.elementID !== undefined) {
         // Check for a passed DOM node.
-        if (typeof that.elementID == 'object' && typeof that.elementID.appendChild == 'function') {
+        if (typeof that.elementID === 'object' && typeof that.elementID.appendChild === 'function') {
             that.container = that.elementID;
         }
         else {

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -126,12 +126,17 @@ Erizo.VideoPlayer = function (spec) {
         that.video.volume = 0;
 
     if (that.elementID !== undefined) {
-        document.getElementById(that.elementID).appendChild(that.div);
-        that.container = document.getElementById(that.elementID);
+        // Check for a passed DOM node.
+        if (typeof that.elementID == 'object' && typeof that.elementID.appendChild == 'function') {
+            that.container = that.elementID;
+        }
+        else {
+            that.container = document.getElementById(that.elementID);
+        }
     } else {
-        document.body.appendChild(that.div);
         that.container = document.body;
     }
+    that.container.appendChild(that.div);
 
     that.parentNode = that.div.parentNode;
 


### PR DESCRIPTION
current code assumes that the element to attach the player to already exists
in the DOM, however, many new frameworks allow manipulating DOM trees prior
to DOM insertion. this patch allows the show/play methods to accept a DOM
node as well as a string identifier.