### PR TITLE
Fix memory leak ExternalOutput

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -98,6 +98,7 @@ private:
     int deliverVideoData_(char* buf, int len);
     void writeAudioData(char* buf, int len);
     void writeVideoData(char* buf, int len);
+    bool bufferCheck(RTPPayloadVP8* payload);
 };
 }
 #endif /* EXTERNALOUTPUT_H_ */


### PR DESCRIPTION
Fix a memory leak in ExternalOutput which appear when the frame dimensions are bigger than buffer (especially when resolution > 640 x 480)
The frames are now dropped, preventing erizoJs to crash.