### PR TITLE
Change shebang to /usr/bin/env bash for increased portability + warn when using unsupported node version.

### DIFF
--- a/erizo/buildProject.sh
+++ b/erizo/buildProject.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 runcmake() {
    cmake ../src
    echo "Done"

--- a/erizo/generateEclipseProject.sh
+++ b/erizo/generateEclipseProject.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BIN_DIR="build"
 if [ -d $BIN_DIR ]; then
   cd $BIN_DIR
@@ -9,4 +9,4 @@ if [ -d $BIN_DIR ]; then
 else
   echo "Error, build directory does not exist, run generateProject.sh first"
 fi
-  
+

--- a/erizo/generateProject.sh
+++ b/erizo/generateProject.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 runcmake() {
    cmake ../src
    echo "Done"

--- a/erizoAPI/build.sh
+++ b/erizoAPI/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if hash node-waf 2>/dev/null; then
   echo 'building with node-waf'
   rm -rf build

--- a/erizo_controller/erizoAgent/launch.sh
+++ b/erizo_controller/erizoAgent/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/../../erizo/build/erizo
 ulimit -c unlimited
 

--- a/erizo_controller/erizoClient/extras/firefox-extension/createExtension.sh
+++ b/erizo_controller/erizoClient/extras/firefox-extension/createExtension.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Creating FirefoxExtension.xpi..."
 

--- a/erizo_controller/erizoClient/tools/compile.sh
+++ b/erizo_controller/erizoClient/tools/compile.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 java -jar compiler.jar --js ../lib/socket.io.js --js ../src/Events.js --js ../src/webrtc-stacks/FcStack.js --js ../src/webrtc-stacks/BowserStack.js --js ../src/webrtc-stacks/FirefoxStack.js --js ../src/webrtc-stacks/ChromeStableStack.js --js ../src/webrtc-stacks/ChromeCanaryStack.js --js ../src/Connection.js --js ../src/Stream.js --js ../src/Room.js --js ../src/utils/L.Logger.js --js ../src/utils/L.Base64.js --js ../src/utils/L.Resizer.js --js ../src/views/View.js --js ../src/views/VideoPlayer.js --js ../src/views/AudioPlayer.js --js ../src/views/Bar.js --js ../src/views/Speaker.js --js_output_file ../dist/erizo.js

--- a/erizo_controller/erizoClient/tools/compileDebug.sh
+++ b/erizo_controller/erizoClient/tools/compileDebug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 FILE=../dist/erizo.js
 rm $FILE
 cat ../lib/socket.io.js >> $FILE

--- a/erizo_controller/erizoClient/tools/compilefc.sh
+++ b/erizo_controller/erizoClient/tools/compilefc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -d $LIB_DIR ]; then
 	rm -rf ../build

--- a/erizo_controller/erizoClient/tools/compilefcDebug.sh
+++ b/erizo_controller/erizoClient/tools/compilefcDebug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 FILE=../build/erizofc.js
 TARGET=../dist/erizofc.js
 rm $FILE

--- a/erizo_controller/initErizo_agent.sh
+++ b/erizo_controller/initErizo_agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/erizo_controller/initErizo_controller.sh
+++ b/erizo_controller/initErizo_controller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/erizo_controller/installErizoTest.sh
+++ b/erizo_controller/installErizoTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo [erizo_controller] Installing erizoTest
 

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo [erizo_controller] Installing node_modules for erizo_controller
 

--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "config.erizoController.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
 mongod --dbpath /opt/licode/build/db --logpath /opt/licode/build/mongo.log --fork
 cd /opt/licode/scripts

--- a/nuve/initNuve.sh
+++ b/nuve/initNuve.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 ROOT=`dirname $SCRIPT`

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/nuve/nuveClient/tools/compile.sh
+++ b/nuve/nuveClient/tools/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir ../dist
 mkdir ../build

--- a/nuve/nuveClient/tools/compileDist.sh
+++ b/nuve/nuveClient/tools/compileDist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 java -jar compiler.jar --js ../lib/xmlhttprequest.js --js_output_file ../dist/xmlhttprequest.js
 

--- a/scripts/initBasicExample.sh
+++ b/scripts/initBasicExample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/initLicode.sh
+++ b/scripts/initLicode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/installBasicExample.sh
+++ b/scripts/installBasicExample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/installCentOsDeps.sh
+++ b/scripts/installCentOsDeps.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -33,14 +34,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 install_apt_deps(){
@@ -71,7 +72,7 @@ install_libnice(){
     tar -zxvf libnice-0.1.4.tar.gz
     cd libnice-0.1.4
     patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR 
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -157,7 +158,7 @@ install_glib2(){
     tar -xvf glib-2.38.2.tar.xz
     cd glib-2.38.2
     ./configure --prefix=$PREFIX_DIR
-    make 
+    make
     make install
     cd $CURRENT_DIR
   else
@@ -166,7 +167,7 @@ install_glib2(){
   fi
 
 }
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*

--- a/scripts/installCentOsDepsUnattended.sh
+++ b/scripts/installCentOsDepsUnattended.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -33,14 +33,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 install_apt_deps(){
@@ -71,7 +71,7 @@ install_libnice(){
     tar -zxvf libnice-0.1.4.tar.gz
     cd libnice-0.1.4
     patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR 
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -157,7 +157,7 @@ install_glib2(){
     tar -xvf glib-2.38.2.tar.xz
     cd glib-2.38.2
     ./configure --prefix=$PREFIX_DIR
-    make 
+    make
     make install
     cd $CURRENT_DIR
   else
@@ -166,7 +166,7 @@ install_glib2(){
   fi
 
 }
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -12,6 +12,18 @@ PREFIX_DIR=$LIB_DIR/build/
 
 export ERIZO_HOME=$ROOT/erizo
 
+NODE_VERSION=`node -v`
+
+export ERIZO_HOME=$ROOT/erizo
+
+if [[ $NODE_VERSION != *"0.10"* ]]
+then
+  echo "================================================================"
+  echo "     WARNING: Your node version is curently $NODE_VERSION."
+  echo "     Licode only supports node version 0.10.x. Errors may occur."
+  echo "================================================================"
+fi
+
 usage()
 {
 cat << EOF

--- a/scripts/installLinuxDependencies.sh
+++ b/scripts/installLinuxDependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -42,14 +42,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 os_type()
@@ -105,7 +105,7 @@ checkOrInstallnpm(){
 }
 
 install_apt_deps(){
-  echo "$(os_type) installation" 
+  echo "$(os_type) installation"
   case $(os_type) in
     CentOS )
       sudo yum install npm --enablerepo=epel
@@ -126,7 +126,7 @@ install_apt_deps(){
       sudo yum install log4cxx-devel
       sudo yum install log4cxx
       #TODO: Check JDK package
-      checkOrInstallnpm node-gyp     
+      checkOrInstallnpm node-gyp
       ;;
     Debian )
       sudo apt-get update
@@ -158,7 +158,7 @@ install_apt_deps(){
       checkOrInstallaptitude libvpx-dev
       checkOrInstallaptitude libtool
       checkOrInstallaptitude automake
-      checkOrInstallaptitude curl      
+      checkOrInstallaptitude curl
       checkOrInstallaptitude mongodb
       checkOrInstallaptitude rabbitmq-server
       checkOrInstallaptitude libboost-test-dev
@@ -202,7 +202,7 @@ install_libnice(){
       ./configure --prefix=$PREFIX_DIR
       make -s V=0
       make install
-    fi    
+    fi
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR
@@ -280,7 +280,7 @@ install_libsrtp(){
   cd $CURRENT_DIR
 }
 
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -81,7 +81,7 @@ install_libsrtp(){
 }
 
 install_mediadeps(){
-  brew install opus libvpx x264 
+  brew install opus libvpx x264
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     curl -O https://www.libav.org/releases/libav-11.6.tar.gz
@@ -100,7 +100,7 @@ install_mediadeps(){
 }
 
 install_mediadeps_nogpl(){
-  brew install opus libvpx 
+  brew install opus libvpx
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     curl -O https://www.libav.org/releases/libav-11.6.tar.gz

--- a/scripts/installNuve.sh
+++ b/scripts/installNuve.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`

--- a/scripts/installTravisDeps.sh
+++ b/scripts/installTravisDeps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -33,14 +33,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 install_apt_deps(){
@@ -144,7 +144,7 @@ install_libsrtp(){
 }
 
 
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*

--- a/scripts/installUbuntuDepsUnattended.sh
+++ b/scripts/installUbuntuDepsUnattended.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -33,14 +33,14 @@ check_proxy(){
   else
     echo "http proxy configured, configuring npm"
     npm config set proxy $http_proxy
-  fi  
+  fi
 
   if [ -z "$https_proxy" ]; then
     echo "No https proxy set, doing nothing"
   else
     echo "https proxy configured, configuring npm"
     npm config set https-proxy $https_proxy
-  fi  
+  fi
 }
 
 install_apt_deps(){
@@ -169,7 +169,7 @@ install_libsrtp(){
   fi
 }
 
-cleanup(){  
+cleanup(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     rm -r libnice*

--- a/spine/installSpine.sh
+++ b/spine/installSpine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo [spine] Installing node_modules for Spine
 


### PR DESCRIPTION
Previously the shebang line was: `#!/bin/bash` which is not always the location for `bash` for all systems.

Changing it to `#!/usr/bin/env bash` will use the first `bash` found in `PATH` and increase portability across more platforms.

Reference: http://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang

Also, print a warning to stdout when compiling Erizo components with an unsupported node version. 