### PR TITLE
Add a warning when using an unsupported version of node for Erizo

### DIFF
--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -12,6 +12,18 @@ PREFIX_DIR=$LIB_DIR/build/
 
 export ERIZO_HOME=$ROOT/erizo
 
+NODE_VERSION=`node -v`
+
+export ERIZO_HOME=$ROOT/erizo
+
+if [[ $NODE_VERSION != *"0.10"* ]]
+then
+  echo "================================================================"
+  echo "     WARNING: Your node version is curently $NODE_VERSION."
+  echo "     Licode only supports node version 0.10.x. Errors may occur."
+  echo "================================================================"
+fi
+
 usage()
 {
 cat << EOF

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -8,10 +8,6 @@ BUILD_DIR=$ROOT/build
 CURRENT_DIR=`pwd`
 LIB_DIR=$BUILD_DIR/libdeps
 PREFIX_DIR=$LIB_DIR/build/
-
-
-export ERIZO_HOME=$ROOT/erizo
-
 NODE_VERSION=`node -v`
 
 export ERIZO_HOME=$ROOT/erizo


### PR DESCRIPTION
Since many of us use Node Version Manager to switch between different versions of node, it would be helpful to show a warning if we're using the wrong version of node to compile Erizo.