### PR TITLE
Replaced aws-lib with aws-sdk

### DIFF
--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -244,32 +244,34 @@ for (k in interfaces) {
 
 privateIP = addresses[0];
 
-if (GLOBAL.config.erizoAgent.publicIP === '' || GLOBAL.config.erizoAgent.publicIP === undefined){
+if (GLOBAL.config.erizoAgent.publicIP === '' || GLOBAL.config.erizoAgent.publicIP === undefined) {
     publicIP = addresses[0];
-    if(global.config.cloudProvider.name === 'amazon'){ 
-        var opt = {version: '2012-12-01'};
-        if (GLOBAL.config.cloudProvider.host !== '') {
-            opt.host = GLOBAL.config.cloudProvider.host;
-        }
-        ec2 = require('aws-lib').createEC2Client(GLOBAL.config.cloudProvider.accessKey, GLOBAL.config.cloudProvider.secretAccessKey, opt);
-        ec2.call('DescribeInstances', {'Filter.1.Name':'private-ip-address', 'Filter.1.Value':privateIP}, function (err, response) {
+    if (global.config.cloudProvider.name === 'amazon') {
+        var AWS = require('aws-sdk');
+        new AWS.MetadataService({
+            httpOptions: {
+                timeout: 5000
+            }
+        }).request('/latest/meta-data/public-ipv4', function(err, data) {
             if (err) {
                 log.info('Error: ', err);
-            } else if (response) {
-                publicIP = response.reservationSet.item.instancesSet.item.ipAddress;
-                log.info('public IP: ', publicIP);
+            } else {
+                log.info('Got public ip: ', data);
+                publicIP = data;
+                fillErizos();
             }
         });
+    } else {
+        fillErizos();
     }
 } else {
     publicIP = GLOBAL.config.erizoAgent.publicIP;
+    fillErizos();
 }
 
 // Will clean all erizoJS on those signals
 process.on('SIGINT', cleanErizos); 
 process.on('SIGTERM', cleanErizos);
-
-fillErizos();
 
 amqper.connect(function () {
     "use strict";

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -14,7 +14,7 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-npm install --loglevel error amqp express mongojs aws-lib log4js node-getopt body-parser
+npm install --loglevel error amqp express mongojs aws-sdk log4js node-getopt body-parser
 echo [nuve] Done, node_modules installed
 
 cd ../nuveClient/tools

--- a/nuve/nuveAPI/cloudHandler.js
+++ b/nuve/nuveAPI/cloudHandler.js
@@ -6,7 +6,7 @@ var logger = require('./logger').logger;
 // Logger
 var log = logger.getLogger("CloudHandler");
 
-var ec2;
+var AWS;
 
 var INTERVAL_TIME_EC_READY = 500;
 var TOTAL_ATTEMPTS_EC_READY = 20;
@@ -114,22 +114,20 @@ var addNewAmazonErizoController = function(privateIP, hostname, port, ssl, callb
     var publicIP;
     var instaceId;
 
-    if (ec2 === undefined) {
-        var opt = {version: '2012-12-01'};
-        if (config.cloudProvider.host !== '') {
-            opt.host = config.cloudProvider.host;
-        }
-        ec2 = require('aws-lib').createEC2Client(config.cloudProvider.accessKey, config.cloudProvider.secretAccessKey, opt);
+    if (AWS === undefined) {
+        AWS = require('aws-sdk');
     }
     log.info('private ip ', privateIP);
-
-    ec2.call('DescribeInstances', {'Filter.1.Name':'private-ip-address', 'Filter.1.Value':privateIP}, function (err, response) {
-
+    new AWS.MetadataService({
+        httpOptions: {
+            timeout: 5000
+        }
+    }).request('/latest/meta-data/public-ipv4', function(err, data) {
         if (err) {
             log.info('Error: ', err);
             callback('error');
-        } else if (response) {
-            publicIP = response.reservationSet.item.instancesSet.item.ipAddress;
+        } else {
+            publicIP = data;
             log.info('public IP: ', publicIP);
             addNewPrivateErizoController(publicIP, hostname, port, ssl, callback);
         }

--- a/nuve/nuveAPI/cloudHandler.js
+++ b/nuve/nuveAPI/cloudHandler.js
@@ -132,7 +132,7 @@ var addNewAmazonErizoController = function(privateIP, hostname, port, ssl, callb
             addNewPrivateErizoController(publicIP, hostname, port, ssl, callback);
         }
     });
-}
+};
 
 var addNewPrivateErizoController = function (ip, hostname, port, ssl, callback) {
     "use strict";

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -17,11 +17,7 @@ config.logger.config_file = '../log4js_configuration.json'; //default value: "..
  It's used by Nuve and ErizoController
 **********************************************************/
 config.cloudProvider = {};
-config.cloudProvider.name = '';
-//In Amazon Ec2 instances you can specify the zone host. By default is 'ec2.us-east-1a.amazonaws.com' 
-config.cloudProvider.host = '';
-config.cloudProvider.accessKey = '';
-config.cloudProvider.secretAccessKey = '';
+config.cloudProvider.name = ''; // currently only 'amazon' supported
 
 /*********************************************************
  NUVE CONFIGURATION


### PR DESCRIPTION
related to: https://github.com/ging/licode/pull/445

I decided to switch from aws-lib to aws-sdk (which is the official one I think).
Anyway, it appears that using AWS.Metadata we are able to obtain our public ip from amazon without the need to create an IAM role and hardcode our public / secret aws keys in our code and without specify the region.

rapidly tested and seems working. 
