### PR TITLE
urgent: fix for mongojs installed which not compatible with node 0.10.x

### DIFF
--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -14,7 +14,7 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-npm install --loglevel error amqp express mongojs aws-lib log4js node-getopt body-parser
+npm install --loglevel error amqp express mongojs@2.3.0 aws-lib log4js node-getopt body-parser
 echo [nuve] Done, node_modules installed
 
 cd ../nuveClient/tools


### PR DESCRIPTION
The mongojs lib was updated from 2.3.0 -> 2.4.0 which uses some features like object.assign which are not supported by 0.10.x.

I would suggest making a proper package.json file for all the needed libs. Its actually quite brittle the way it is now.