### PR TITLE
Fix L.Resizer error when bundling / webpack

### DIFF
--- a/erizo_controller/erizoClient/src/utils/L.Resizer.js
+++ b/erizo_controller/erizoClient/src/utils/L.Resizer.js
@@ -3,17 +3,17 @@
  * directory of this distribution and at
  * https://github.com/marcj/css-element-queries/blob/master/LICENSE.
  */
+
+var L = L || {};
 ;
 (function() {
-
-    this.L = this.L || {};
 
     /**
      *
      * @type {Function}
      * @constructor
      */
-    this.L.ElementQueries = function() {
+    L.ElementQueries = function() {
         /**
          *
          * @param element
@@ -242,7 +242,7 @@
      *
      * @constructor
      */
-    this.L.ResizeSensor = function(element, callback) {
+    L.ResizeSensor = function(element, callback) {
         /**
          * Adds a listener to the over/under-flow event.
          *


### PR DESCRIPTION
this.L = this.L = {} was the cause of multiple errors while I was making a library for wrapping erizo client for use in webpack / browserify etc, similar to [this](https://www.npmjs.com/package/erizo-client) but with auto-updating and a respiratory for people to contribute