### PR TITLE
Check payload before setting videoSourceSsrc_

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -315,7 +315,9 @@ int ExternalOutput::deliverAudioData_(char* buf, int len) {
 int ExternalOutput::deliverVideoData_(char* buf, int len) {
     if (videoSourceSsrc_ == 0){
       RtpHeader* h = reinterpret_cast<RtpHeader*>(buf);
-      videoSourceSsrc_ = h->getSSRC();
+      if (h->getPayloadType() == RED_90000_PT){
+          videoSourceSsrc_ = h->getSSRC();
+      }
     }
     this->queueData(buf,len,VIDEO_PACKET);
     return 0;


### PR DESCRIPTION
It happens that sometimes the first packet is not a RED_90000_PT payload type but instead a 72.
This will cause the wrong videoSourceSsrc_ to be set for the Feedback sink, causing:

WARN: WebRtcConnection - Unknown SSRC in deliverFeedback_  3682841650, localVideo 4216015602, remoteVideo 55543, ignoring at every keyframe request