### PR TITLE
Added identifier for every erizo log using log4cxx MDC

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -16,10 +16,12 @@ DEFINE_LOGGER(Resender, "Resender");
 
 Resender::Resender(boost::shared_ptr<NiceConnection> nice, unsigned int comp, const unsigned char* data, unsigned int len) : 
   nice_(nice), comp_(comp), data_(data),len_(len), timer(service) {
+    logContext_ = GET_LOG_CONTEXT();
     sent_ = 0;
   }
 
 Resender::~Resender() {
+  UPDATE_LOG_CONTEXT(logContext_);
   ELOG_DEBUG("Resender destructor");
   timer.cancel();
   if (thread_.get()!=NULL) {
@@ -35,6 +37,7 @@ void Resender::cancel() {
 }
 
 void Resender::start() {
+  UPDATE_LOG_CONTEXT(logContext_);
   sent_ = 0;
   timer.cancel();
   if (thread_.get()!=NULL) {
@@ -48,6 +51,7 @@ void Resender::start() {
 }
 
 void Resender::run() {
+  UPDATE_LOG_CONTEXT(logContext_);
   service.run();
 }
 
@@ -77,6 +81,7 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, b
   Transport(med, transport_name, bundle, rtcp_mux, transportListener, iceConfig), 
   readyRtp(false), readyRtcp(false), running_(false), isServer_(isServer) {
     ELOG_DEBUG( "Initializing DtlsTransport" );
+    logContext_ = GET_LOG_CONTEXT();
     dtlsRtp.reset(new DtlsSocketContext());
 
     int comps = 1;
@@ -330,6 +335,7 @@ void DtlsTransport::processLocalSdp(SdpInfo *localSdp_) {
 }
 
 void DtlsTransport::getNiceDataLoop(){
+  UPDATE_LOG_CONTEXT(logContext_);
   while(running_){
     p_ = nice_->getPacket();
     if (p_->length > 0) {

--- a/erizo/src/erizo/DtlsTransport.h
+++ b/erizo/src/erizo/DtlsTransport.h
@@ -43,6 +43,7 @@ namespace erizo {
     bool running_, isServer_;
     boost::scoped_ptr<Resender> rtcpResender, rtpResender;
     boost::thread getNice_Thread_;
+    std::string logContext_;
     void getNiceDataLoop();
     packetPtr p_;
   };
@@ -63,6 +64,7 @@ namespace erizo {
     int sent_;
     const unsigned char* data_;
     unsigned int len_;
+    std::string logContext_;
     boost::asio::io_service service;
     boost::asio::deadline_timer timer;
     boost::scoped_ptr<boost::thread> thread_;

--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -104,6 +104,7 @@ protected:
     unsigned int audioSourceSSRC_;
     MediaSink* videoSink_;
     MediaSink* audioSink_;
+    std::string sourceId_;
     //can it accept feedback
     FeedbackSink* sourcefbSink_;
 public:
@@ -121,6 +122,7 @@ public:
         return sourcefbSink_;
     }
     virtual int sendPLI()=0;
+
     unsigned int getVideoSourceSSRC (){
         boost::mutex::scoped_lock lock(myMonitor_);
         return videoSourceSSRC_;
@@ -137,6 +139,9 @@ public:
         boost::mutex::scoped_lock lock(myMonitor_);
         audioSourceSSRC_ = ssrc;
     }
+    const std::string& getSourceId(){
+      return sourceId_;
+    };
     virtual ~MediaSource(){}
 };
 

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -59,6 +59,7 @@ namespace erizo {
     mediaType(med), agent_(NULL), loop_(NULL), listener_(listener), candsDelivered_(0), 
     iceState_(NICE_INITIAL), iceComponents_(iceComponents), username_(username), password_(password), iceConfig_(iceConfig),
   receivedLastCandidate_(false){
+      logContext_=GET_LOG_CONTEXT();
       localCandidates.reset(new std::vector<CandidateInfo>());
       transportName.reset(new std::string(transport_name));
       for (unsigned int i = 1; i<=iceComponents_; i++) {
@@ -245,6 +246,7 @@ namespace erizo {
 
   void NiceConnection::mainLoop() {
     //Start gathering candidates and fire event loop
+    UPDATE_LOG_CONTEXT(logContext_);
     ELOG_DEBUG("Starting g_ main_loop %p", this);
     if (agent_==NULL){
       return;

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -184,6 +184,7 @@ namespace erizo {
     unsigned int iceComponents_;
     std::map <unsigned int, IceState> comp_state_list_;
     std::string ufrag_, upass_, username_, password_;
+    std::string logContext_;
     IceConfig iceConfig_;
     bool receivedLastCandidate_;
   };

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -9,17 +9,18 @@
 namespace erizo {
   DEFINE_LOGGER(OneToManyProcessor, "OneToManyProcessor");
   OneToManyProcessor::OneToManyProcessor() {
+    UPDATE_LOG_CONTEXT("unassigned");
     ELOG_DEBUG ("OneToManyProcessor constructor");
     feedbackSink_ = NULL;
   }
 
   OneToManyProcessor::~OneToManyProcessor() {
+    UPDATE_LOG_CONTEXT(id_);
     ELOG_DEBUG ("OneToManyProcessor destructor");
     this->closeAll();
   }
 
   int OneToManyProcessor::deliverAudioData_(char* buf, int len) {
- //   ELOG_DEBUG ("OneToManyProcessor deliverAudio");
     if (len <= 0)
       return 0;
 
@@ -61,7 +62,10 @@ namespace erizo {
 
   void OneToManyProcessor::setPublisher(MediaSource* webRtcConn) {
     boost::mutex::scoped_lock lock(myMonitor_);
+    id_ = webRtcConn->getSourceId();
+    UPDATE_LOG_CONTEXT(id_);
     this->publisher.reset(webRtcConn);
+
     feedbackSink_ = publisher->getFeedbackSink();
   }
 
@@ -75,6 +79,7 @@ namespace erizo {
 
   void OneToManyProcessor::addSubscriber(MediaSink* webRtcConn,
       const std::string& peerId) {
+    UPDATE_LOG_CONTEXT(id_);
     ELOG_DEBUG("Adding subscriber");
     boost::mutex::scoped_lock lock(myMonitor_);
     ELOG_DEBUG("From %u, %u ", publisher->getAudioSourceSSRC() , publisher->getVideoSourceSSRC());
@@ -95,6 +100,7 @@ namespace erizo {
   }
 
   void OneToManyProcessor::removeSubscriber(const std::string& peerId) {
+    UPDATE_LOG_CONTEXT(id_);
     ELOG_DEBUG("Remove subscriber %s", peerId.c_str());
     boost::mutex::scoped_lock lock(myMonitor_);
     if (this->subscribers.find(peerId) != subscribers.end()) {
@@ -103,6 +109,7 @@ namespace erizo {
   }
 
   void OneToManyProcessor::closeAll() {
+    UPDATE_LOG_CONTEXT(id_);
     ELOG_DEBUG ("OneToManyProcessor closeAll");
     feedbackSink_ = NULL;
     publisher.reset();

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -48,6 +48,7 @@ public:
 
 private:
   typedef boost::shared_ptr<MediaSink> sink_ptr;
+  std::string id_;
   FeedbackSink* feedbackSink_;
 	
   int deliverAudioData_(char* buf, int len);

--- a/erizo/src/erizo/logger.h
+++ b/erizo/src/erizo/logger.h
@@ -23,11 +23,12 @@
 #include <stdio.h>
 
 #include <log4cxx/logger.h>
+#include <log4cxx/mdc.h>
 #include <log4cxx/helpers/exception.h>
 
  #define DECLARE_LOGGER() \
  static log4cxx::LoggerPtr logger;
-
+ 
  #define DEFINE_LOGGER(namespace, logName) \
  log4cxx::LoggerPtr namespace::logger = log4cxx::Logger::getLogger( logName );
 
@@ -100,5 +101,16 @@
 
 #define ELOG_FATAL(fmt, args...) \
     ELOG_FATAL2( logger, fmt, ##args );
+
+static const std::string LOG_CONTEXT_ID = "connId";
+
+static inline void UPDATE_LOG_CONTEXT(const std::string& value){
+    log4cxx::MDC::clear();
+    log4cxx::MDC::put(LOG_CONTEXT_ID, value);
+}
+
+static inline std::string GET_LOG_CONTEXT(){
+  return log4cxx::MDC::get(LOG_CONTEXT_ID);
+}
 
 #endif  /* __ELOG_H__ */

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -10,6 +10,8 @@
 namespace erizo {
   DEFINE_LOGGER(ExternalInput, "media.ExternalInput");
   ExternalInput::ExternalInput(const std::string& inputUrl):url_(inputUrl){
+    UPDATE_LOG_CONTEXT(inputUrl);
+    this->sourceId_ = inputUrl;
     sourcefbSink_=NULL;
     context_ = NULL;
     running_ = false;
@@ -19,6 +21,7 @@ namespace erizo {
   }
 
   ExternalInput::~ExternalInput(){
+    UPDATE_LOG_CONTEXT(url_);
     ELOG_DEBUG("Destructor ExternalInput %s" , url_.c_str());
     ELOG_DEBUG("Closing ExternalInput");
     running_ = false;
@@ -32,6 +35,7 @@ namespace erizo {
   }
 
   int ExternalInput::init(){
+    UPDATE_LOG_CONTEXT(url_);
     context_ = avformat_alloc_context();
     av_register_all();
     avcodec_register_all();
@@ -170,6 +174,7 @@ namespace erizo {
 
   void ExternalInput::receiveLoop(){
 
+    UPDATE_LOG_CONTEXT(url_);
     av_read_play(context_);//play RTSP
     int gotDecodedFrame = 0;
     int length;
@@ -223,6 +228,7 @@ namespace erizo {
   }
 
   void ExternalInput::encodeLoop() {
+    UPDATE_LOG_CONTEXT(url_);
     while (running_ == true) {
       queueMutex_.lock();
       if (packetQueue_.size() > 0) {

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -53,6 +53,7 @@ private:
     unsigned char* unpackagedBufferpart_;
     unsigned char deliverMediaBuffer_[3000];
     unsigned char unpackagedBuffer_[UNPACKAGE_BUFFER_SIZE];
+    std::string url_;
 
     // Timestamping strategy: we use the RTP timestamps so we don't have to restamp and we're not
     // subject to error due to the RTP packet queue depth and playout.

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -7,7 +7,7 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 # Print the date in ISO 8601 format
-log4j.appender.A1.layout.ConversionPattern=%d  - %p: %c - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d - %t  - %p: %c - %X{connId} - %m%n
 
 log4j.logger.DtlsTransport=DEBUG
 log4j.logger.NiceConnection=DEBUG
@@ -28,7 +28,6 @@ log4j.logger.media.ExternalOutput=WARN
 log4j.logger.media.InputProcessor=WARN
 log4j.logger.media.OneToManyTranscoder=WARN
 log4j.logger.media.OutputProcessor=WARN
-
 
 log4j.logger.media.codecs.VideoEncoder=WARN
 log4j.logger.media.codecs.VideoDecoder=WARN


### PR DESCRIPTION
Erizo will now include contextual information on every log message.
That information allows to assign any operation to it's publisher, subscriber, externalInput or externalOutput.
It's implemented using log4cxx MDC which means we have to manage the context depending on the thread we're. 
Rule of thumb: we update the context for every call that is triggered by the node main thread and we copy the context for every new thread we start.

We clear the context every time we update it because updating does not work in log4cxx and the MDC constructor and destructor also don't work.
