### PR TITLE
Provide connection context in logs

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -76,7 +76,7 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, c
     const IceConfig& iceConfig, std::string username, std::string password, bool isServer):
   Transport(med, transport_name, connection_id, bundle, rtcp_mux, transportListener, iceConfig),
   readyRtp(false), readyRtcp(false), running_(false), isServer_(isServer) {
-    ELOG_DEBUG( "%s, message: constructor, transportName:%s, bundle:%d", toLog(), transport_name.c_str(), bundle);
+    ELOG_DEBUG( "%s, message: constructor, transportName:%s, isBundle:%d", toLog(), transport_name.c_str(), bundle);
     dtlsRtp.reset(new DtlsSocketContext());
 
     int comps = 1;
@@ -111,10 +111,10 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, c
   }
 
 DtlsTransport::~DtlsTransport() {
-  ELOG_DEBUG("%s, message: destructor", toLog());
+  ELOG_DEBUG("%s, message: destroying", toLog());
   if (this->state_!=TRANSPORT_FINISHED)
     this->close();
-  ELOG_DEBUG("%s, message: destructor END", toLog());
+  ELOG_DEBUG("%s, message: destroyed", toLog());
 }
 
 void DtlsTransport::start() {
@@ -136,7 +136,7 @@ void DtlsTransport::onNiceData(unsigned int component_id, char* data, int len, N
   int length = len;
   SrtpChannel *srtp = srtp_.get();
   if (DtlsTransport::isDtlsPacket(data, len)) {
-    ELOG_DEBUG("%s, message: Received DTLS message, transportName: %s, component_id: %u",toLog(), transport_name.c_str(), component_id);
+    ELOG_DEBUG("%s, message: Received DTLS message, transportName: %s, componentId: %u",toLog(), transport_name.c_str(), component_id);
     if (component_id == 1) {
       if (rtpResender.get()!=NULL) {
         rtpResender->cancel();
@@ -286,7 +286,7 @@ std::string DtlsTransport::getMyFingerprint() {
 }
 
 void DtlsTransport::updateIceState(IceState state, NiceConnection *conn) {
-  ELOG_DEBUG( "%s, message:NiceState, transportName: %s, state: %d, bundle: %d", toLog(), transport_name.c_str(), state, bundle_);
+  ELOG_DEBUG( "%s, message:NiceState, transportName: %s, state: %d, isBundle: %d", toLog(), transport_name.c_str(), state, bundle_);
   if (state == NICE_INITIAL && this->getTransportState() != TRANSPORT_STARTED) {
     updateTransportState(TRANSPORT_STARTED);
   }

--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -76,7 +76,7 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, c
     const IceConfig& iceConfig, std::string username, std::string password, bool isServer):
   Transport(med, transport_name, connection_id, bundle, rtcp_mux, transportListener, iceConfig),
   readyRtp(false), readyRtcp(false), running_(false), isServer_(isServer) {
-    ELOG_DEBUG( "%s, message: constructor, transport_name:%s, bundle:%d", toLog(), transport_name.c_str(), bundle);
+    ELOG_DEBUG( "%s, message: constructor, transportName:%s, bundle:%d", toLog(), transport_name.c_str(), bundle);
     dtlsRtp.reset(new DtlsSocketContext());
 
     int comps = 1;
@@ -136,7 +136,7 @@ void DtlsTransport::onNiceData(unsigned int component_id, char* data, int len, N
   int length = len;
   SrtpChannel *srtp = srtp_.get();
   if (DtlsTransport::isDtlsPacket(data, len)) {
-    ELOG_DEBUG("%s, message: Received DTLS message, transport_name: %s, component_id: %u",toLog(), transport_name.c_str(), component_id);
+    ELOG_DEBUG("%s, message: Received DTLS message, transportName: %s, component_id: %u",toLog(), transport_name.c_str(), component_id);
     if (component_id == 1) {
       if (rtpResender.get()!=NULL) {
         rtpResender->cancel();
@@ -237,7 +237,7 @@ void DtlsTransport::writeDtls(DtlsSocketContext *ctx, const unsigned char* data,
     rtpResender->start();
   }
 
-  ELOG_DEBUG("%s, message: Sending DTLS message, transport_name: %s, component_id: %d", toLog(), transport_name.c_str(), comp);
+  ELOG_DEBUG("%s, message: Sending DTLS message, transportName: %s, componentId: %d", toLog(), transport_name.c_str(), comp);
 
   nice_->sendData(comp, data, len);
 }
@@ -269,14 +269,14 @@ void DtlsTransport::onHandshakeCompleted(DtlsSocketContext *ctx, std::string cli
       updateTransportState(TRANSPORT_FAILED);
     }
   }
-  ELOG_DEBUG("%s, message:HandShakeCompleted, transport_name:%s, readyRtp:%d, readyRtcp:%d", toLog(), transport_name.c_str(), readyRtp, readyRtcp);
+  ELOG_DEBUG("%s, message:HandShakeCompleted, transportName:%s, readyRtp:%d, readyRtcp:%d", toLog(), transport_name.c_str(), readyRtp, readyRtcp);
   if (readyRtp && readyRtcp) {
     updateTransportState(TRANSPORT_READY);
   }
 }
 
 void DtlsTransport::onHandshakeFailed(DtlsSocketContext *ctx, const std::string error){
-  ELOG_WARN("%s, message: Handshake failed, transport_name:%s, openSSLerror: %s", toLog(), transport_name.c_str(), error.c_str());
+  ELOG_WARN("%s, message: Handshake failed, transportName:%s, openSSLerror: %s", toLog(), transport_name.c_str(), error.c_str());
   running_ = false;
   updateTransportState(TRANSPORT_FAILED);
 }
@@ -286,7 +286,7 @@ std::string DtlsTransport::getMyFingerprint() {
 }
 
 void DtlsTransport::updateIceState(IceState state, NiceConnection *conn) {
-  ELOG_DEBUG( "%s, message:NiceState, transport_name: %s, state: %d, bundle: %d", toLog(), transport_name.c_str(), state, bundle_);
+  ELOG_DEBUG( "%s, message:NiceState, transportName: %s, state: %d, bundle: %d", toLog(), transport_name.c_str(), state, bundle_);
   if (state == NICE_INITIAL && this->getTransportState() != TRANSPORT_STARTED) {
     updateTransportState(TRANSPORT_STARTED);
   }
@@ -300,18 +300,18 @@ void DtlsTransport::updateIceState(IceState state, NiceConnection *conn) {
   }
   else if (state == NICE_READY) {
     if (!isServer_ && dtlsRtp && !dtlsRtp->started) {
-      ELOG_INFO("%s, message: DTLSRTP Start, transport_name: %s", toLog(), transport_name.c_str());
+      ELOG_INFO("%s, message: DTLSRTP Start, transportName: %s", toLog(), transport_name.c_str());
       dtlsRtp->start();
     }
     if (!isServer_ && dtlsRtcp != NULL && (!dtlsRtcp->started || rtcpResender->getStatus() < 0)) {
-      ELOG_DEBUG("%s, message: DTLSRTCP Start, transport_name: %s", toLog(), transport_name.c_str());
+      ELOG_DEBUG("%s, message: DTLSRTCP Start, transportName: %s", toLog(), transport_name.c_str());
       dtlsRtcp->start();
     }
   }
 }
 
 void DtlsTransport::processLocalSdp(SdpInfo *localSdp_) {
-  ELOG_DEBUG("%s, message: processing local sdp, transport_name: %s", toLog(), transport_name.c_str());
+  ELOG_DEBUG("%s, message: processing local sdp, transportName: %s", toLog(), transport_name.c_str());
   localSdp_->isFingerprint = true;
   localSdp_->fingerprint = getMyFingerprint();
   std::string username;
@@ -323,7 +323,7 @@ void DtlsTransport::processLocalSdp(SdpInfo *localSdp_) {
   }else{
     localSdp_->setCredentials(username, password, this->mediaType);
   }
-  ELOG_DEBUG("%s, message: processed local sdp, transport_name: %s, ufrag: %s, pass: %s", toLog(), transport_name.c_str(), 
+  ELOG_DEBUG("%s, message: processed local sdp, transportName: %s, ufrag: %s, pass: %s", toLog(), transport_name.c_str(), 
       username.c_str(), password.c_str());
 }
 

--- a/erizo/src/erizo/DtlsTransport.h
+++ b/erizo/src/erizo/DtlsTransport.h
@@ -17,7 +17,8 @@ namespace erizo {
   class DtlsTransport : dtls::DtlsReceiver, public Transport {
     DECLARE_LOGGER();
     public:
-    DtlsTransport(MediaType med, const std::string &transport_name, bool bundle, bool rtcp_mux, TransportListener *transportListener, const IceConfig& iceConfig, std::string username, std::string password, bool isServer);
+    DtlsTransport(MediaType med, const std::string& transport_name, const std::string& connection_id, bool bundle, bool rtcp_mux, TransportListener *transportListener, 
+        const IceConfig& iceConfig, std::string username, std::string password, bool isServer);
     virtual ~DtlsTransport();
     void connectionStateChanged(IceState newState);
     std::string getMyFingerprint();
@@ -43,8 +44,12 @@ namespace erizo {
     bool running_, isServer_;
     boost::scoped_ptr<Resender> rtcpResender, rtpResender;
     boost::thread getNice_Thread_;
-    void getNiceDataLoop();
     packetPtr p_;
+    
+    void getNiceDataLoop();
+    inline const char* toLog() {
+      return (std::string("id: ")+connection_id_).c_str();
+    };
   };
 
   class Resender {

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -248,7 +248,7 @@ namespace erizo {
       return;
     }
     g_main_loop_run(loop_);
-    ELOG_DEBUG("%s, message: Finished g_main_loop, this: %p", toLog(), this);
+    ELOG_DEBUG("%s, message: finished g_main_loop, this: %p", toLog(), this);
   }
 
   bool NiceConnection::setRemoteCandidates(std::vector<CandidateInfo> &candidates, bool isBundle) {
@@ -257,7 +257,7 @@ namespace erizo {
       return false;
     }
     GSList* candList = NULL;
-    ELOG_DEBUG("%s, message: setting remote candidates, candidate_size: %lu, mediatype: %d", toLog(), candidates.size(), this->mediaType);
+    ELOG_DEBUG("%s, message: setting remote candidates, candidateSize: %lu, mediaType: %d", toLog(), candidates.size(), this->mediaType);
 
     for (unsigned int it = 0; it < candidates.size(); it++) {
       NiceCandidateType nice_cand_type;
@@ -299,7 +299,7 @@ namespace erizo {
         ELOG_DEBUG("%s, message: adding relay or srflx remote candidate, hostType: %d, hostAddress: %s, hostPort %d, rAddress: %s, rPort: %d", toLog(), cinfo.hostType, cinfo.hostAddress.c_str(), 
             cinfo.hostPort, cinfo.rAddress.c_str(), cinfo.rPort);
       }else{
-        ELOG_DEBUG("%s, adding remote candidate, hostType: %d, hostAddress: %s, hostPort: %d, priority: %d, componentId: %d, ufrag: %s, pass: %s", 
+        ELOG_DEBUG("%s, message: adding remote candidate, hostType: %d, hostAddress: %s, hostPort: %d, priority: %d, componentId: %d, ufrag: %s, pass: %s", 
             toLog(), cinfo.hostType, cinfo.hostAddress.c_str(), cinfo.hostPort, cinfo.priority, cinfo.componentId, cinfo.username.c_str(),
             cinfo.password.c_str());
       }
@@ -418,7 +418,7 @@ namespace erizo {
           }
         }
       }else{
-        ELOG_WARN("%s, message: not received all candidates, newComponentState:%u", toLog(), state);
+        ELOG_WARN("%s, message: failed and not received all candidates, newComponentState:%u", toLog(), state);
         return;
       }
     }
@@ -433,7 +433,7 @@ namespace erizo {
 
     if(state <= iceState_) {
       if (state != NICE_READY)
-        ELOG_WARN("%s, message: unexpected ice state transition, iceState:%u  newIceState: %u", toLog(), iceState_, state);
+        ELOG_WARN("%s, message: unexpected ice state transition, iceState:%u,  newIceState: %u", toLog(), iceState_, state);
       return;
     }
 

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -184,7 +184,7 @@ namespace erizo {
         g_value_set_uint(&val2, iceConfig_.stunPort);
         g_object_set_property(G_OBJECT( agent_ ), "stun-server-port", &val2);
 
-        ELOG_DEBUG("%s, message:setting stun, stun_server: %s, stun_port: %d", toLog(), iceConfig_.stunServer.c_str(), iceConfig_.stunPort);
+        ELOG_DEBUG("%s, message:setting stun, stunServer: %s, stunPort: %d", toLog(), iceConfig_.stunServer.c_str(), iceConfig_.stunPort);
       }
 
       // Connect the signals
@@ -198,7 +198,7 @@ namespace erizo {
           G_CALLBACK( cb_new_candidate ), this);
 
       // Create a new stream and start gathering candidates
-      ELOG_DEBUG("%s, adding stream, iceComponents: %d", toLog(), iceComponents_);
+      ELOG_DEBUG("%s, message: adding stream, iceComponents: %d", toLog(), iceComponents_);
       nice_agent_add_stream(agent_, iceComponents_);
       gchar *ufrag = NULL, *upass = NULL;
       nice_agent_get_local_credentials(agent_, 1, &ufrag, &upass);
@@ -401,7 +401,7 @@ namespace erizo {
   }
 
   void NiceConnection::updateComponentState(unsigned int compId, IceState state) {
-    ELOG_DEBUG("%s, message: new ice component state, newComponentState: %u, transport_name: %s, componentId %u, iceComponents: %u", toLog(), state, transportName->c_str(), compId, iceComponents_);
+    ELOG_DEBUG("%s, message: new ice component state, newComponentState: %u, transportName: %s, componentId %u, iceComponents: %u", toLog(), state, transportName->c_str(), compId, iceComponents_);
     comp_state_list_[compId] = state;
     if (state == NICE_READY) {
       for (unsigned int i = 1; i<=iceComponents_; i++) {
@@ -411,7 +411,7 @@ namespace erizo {
       }
     }else if (state == NICE_FAILED){
       if (receivedLastCandidate_){
-        ELOG_WARN("%s, message: component failed, transport_name: %s, componentId: %u", toLog(), transportName->c_str(), compId);
+        ELOG_WARN("%s, message: component failed, transportName: %s, componentId: %u", toLog(), transportName->c_str(), compId);
         for (unsigned int i = 1; i<=iceComponents_; i++) {
           if (comp_state_list_[i] != NICE_FAILED) {
             return;
@@ -437,7 +437,7 @@ namespace erizo {
       return;
     }
 
-    ELOG_INFO("%s, message: iceState transition, transport_name: %s, iceState: %u, newIceState: %u, this: %p", toLog(), transportName->c_str(), 
+    ELOG_INFO("%s, message: iceState transition, transportName: %s, iceState: %u, newIceState: %u, this: %p", toLog(), transportName->c_str(), 
         this->iceState_, state, this);
     this->iceState_ = state;
     switch( iceState_) {

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -54,9 +54,9 @@ namespace erizo {
     conn->updateComponentState(component_id, NICE_READY);
   }
 
-  NiceConnection::NiceConnection(MediaType med, const std::string &transport_name,NiceConnectionListener* listener, 
+  NiceConnection::NiceConnection(MediaType med, const std::string &transport_name, const std::string& connection_id, NiceConnectionListener* listener, 
       unsigned int iceComponents, const IceConfig& iceConfig, std::string username, std::string password) : 
-    mediaType(med), agent_(NULL), loop_(NULL), listener_(listener), candsDelivered_(0), 
+    mediaType(med), connection_id_(connection_id), agent_(NULL), loop_(NULL), listener_(listener), candsDelivered_(0), 
     iceState_(NICE_INITIAL), iceComponents_(iceComponents), username_(username), password_(password), iceConfig_(iceConfig),
   receivedLastCandidate_(false){
       localCandidates.reset(new std::vector<CandidateInfo>());
@@ -69,9 +69,9 @@ namespace erizo {
     }
 
   NiceConnection::~NiceConnection() {
-    ELOG_DEBUG("NiceConnection Destructor");
+    ELOG_DEBUG("%s, message: destroying", toLog());
     this->close();
-    ELOG_DEBUG("NiceConnection Destructor END");
+    ELOG_DEBUG("%s, message: destroyed", toLog());
   }
 
   packetPtr NiceConnection::getPacket(){
@@ -79,7 +79,7 @@ namespace erizo {
     while(niceQueue_.empty()){
       cond_.wait(lock);
       if(this->checkIceState()>=NICE_FINISHED) {
-        ELOG_DEBUG("Sending empty packet, NiceConnection won't send more packets");
+        ELOG_DEBUG("%s, message: finished in getPacket thread", toLog());
         packetPtr p (new dataPacket());
         p->length=-1;
         return p;
@@ -95,35 +95,35 @@ namespace erizo {
     if(this->checkIceState()==NICE_FINISHED){
       return;
     }
-    ELOG_DEBUG("Closing nice  %p", this);
+    ELOG_DEBUG("%s, message:closing", toLog());
     this->updateIceState(NICE_FINISHED);
     if (loop_!=NULL) {
       g_main_loop_quit(loop_);
     }
     if (loop_!=NULL){
-      ELOG_DEBUG("Unrefing loop");
+      ELOG_DEBUG("%s, message:Unrefing loop", toLog());
       g_main_loop_unref(loop_);
       loop_=NULL;
     }
     cond_.notify_one();
     listener_ = NULL;
     boost::system_time const timeout=boost::get_system_time()+ boost::posix_time::milliseconds(500);
-    ELOG_DEBUG("m_thread join %p", this);
+    ELOG_DEBUG("%s, message: m_thread join, this:%p", toLog(), this);
     if (!m_Thread_.timed_join(timeout) ){
-      ELOG_DEBUG("Taking too long to close thread, trying to interrupt %p", this);
+      ELOG_DEBUG("%s, message: interrupt thread to close, this: %p", toLog(), this);
       m_Thread_.interrupt();
     }
     if (agent_!=NULL){
-      ELOG_DEBUG("Unrefing agent");
+      ELOG_DEBUG("%s, message: unrefing agent", toLog());
       g_object_unref(agent_);
       agent_ = NULL;
     }
     if (context_!=NULL) {
-      ELOG_DEBUG("Unrefing context");
+      ELOG_DEBUG("%s, message: Unrefing context", toLog());
       g_main_context_unref(context_);
       context_=NULL;
     }
-    ELOG_DEBUG("Nice Closed %p", this);
+    ELOG_DEBUG("%s, message: closed, this: %p", toLog(), this);
   }
 
   void NiceConnection::queueData(unsigned int component_id, char* buf, int len){
@@ -146,7 +146,7 @@ namespace erizo {
       val = nice_agent_send(agent_, 1, compId, len, reinterpret_cast<const gchar*>(buf));
     }
     if (val != len) {
-      ELOG_DEBUG("Data sent %d of %d", val, len);
+      ELOG_DEBUG("%s, message: Sending less data than expected, sent: %d, to_send: %d", toLog(), val, len);
     }
     return val;
   }
@@ -157,12 +157,11 @@ namespace erizo {
         return;
       }
       context_ = g_main_context_new();
-      ELOG_DEBUG("Creating Nice Agent");
+      ELOG_DEBUG("%s, message: creating Nice Agent", toLog());
       nice_debug_enable( FALSE );
       // Create a nice agent
       agent_ = nice_agent_new(context_, NICE_COMPATIBILITY_RFC5245);
       loop_ = g_main_loop_new(context_, FALSE);
-      ELOG_DEBUG("Starting Main Loop Thread");
       m_Thread_ = boost::thread(&NiceConnection::mainLoop, this);
       GValue controllingMode = { 0 };
       g_value_init(&controllingMode, G_TYPE_BOOLEAN);
@@ -185,7 +184,7 @@ namespace erizo {
         g_value_set_uint(&val2, iceConfig_.stunPort);
         g_object_set_property(G_OBJECT( agent_ ), "stun-server-port", &val2);
 
-        ELOG_DEBUG("Setting STUN server %s:%d", iceConfig_.stunServer.c_str(), iceConfig_.stunPort);
+        ELOG_DEBUG("%s, message:setting stun, stun_server: %s, stun_port: %d", toLog(), iceConfig_.stunServer.c_str(), iceConfig_.stunPort);
       }
 
       // Connect the signals
@@ -199,7 +198,7 @@ namespace erizo {
           G_CALLBACK( cb_new_candidate ), this);
 
       // Create a new stream and start gathering candidates
-      ELOG_DEBUG("Adding Stream... Number of components %d", iceComponents_);
+      ELOG_DEBUG("%s, adding stream, iceComponents: %d", toLog(), iceComponents_);
       nice_agent_add_stream(agent_, iceComponents_);
       gchar *ufrag = NULL, *upass = NULL;
       nice_agent_get_local_credentials(agent_, 1, &ufrag, &upass);
@@ -208,18 +207,18 @@ namespace erizo {
 
       // Set our remote credentials.  This must be done *after* we add a stream.
       if (username_.compare("")!=0 && password_.compare("")!=0){
-        ELOG_DEBUG("Setting remote credentials in constructor");
+        ELOG_DEBUG("%s, message: setting remote credentials in constructor, ufrag:%s, pass:%s", toLog(), username_.c_str(), password_.c_str());
         this->setRemoteCredentials(username_, password_);
       }
       // Set Port Range ----> If this doesn't work when linking the file libnice.sym has to be modified to include this call
       if (iceConfig_.minPort!=0 && iceConfig_.maxPort!=0){
-        ELOG_DEBUG("Setting port range: %d to %d\n", iceConfig_.minPort, iceConfig_.maxPort);
+        ELOG_DEBUG("%s, message: setting port range, minPort: %d, maxPort: %d", toLog(), iceConfig_.minPort, iceConfig_.maxPort);
         nice_agent_set_port_range(agent_, (guint)1, (guint)1, (guint)iceConfig_.minPort, (guint)iceConfig_.maxPort);
       }
 
       if (iceConfig_.turnServer.compare("") != 0 && iceConfig_.turnPort!=0){
-        ELOG_DEBUG("Setting TURN server %s:%d", iceConfig_.turnServer.c_str(), iceConfig_.turnPort);
-        ELOG_DEBUG("Setting TURN credentials %s:%s", iceConfig_.turnUsername.c_str(), iceConfig_.turnPass.c_str());
+        ELOG_DEBUG("%s, message: configuring TURN, turnServer: %s , turnPort: %d, turnUsername: %s, turnPass: %s", toLog(), iceConfig_.turnServer.c_str(), 
+            iceConfig_.turnPort, iceConfig_.turnUsername.c_str(), iceConfig_.turnPass.c_str());
 
         for (unsigned int i = 1; i <= iceComponents_ ; i++){
           nice_agent_set_relay_info     (agent_,
@@ -236,21 +235,20 @@ namespace erizo {
       if(agent_){
         for (unsigned int i = 1; i<=iceComponents_; i++){
           nice_agent_attach_recv(agent_, 1, i, context_, cb_nice_recv, this);
-          ELOG_DEBUG("Gathering candidates %p", this);
         }
       }
-    ELOG_DEBUG("Starting gather candidates");
-    nice_agent_gather_candidates(agent_, 1);   
+      ELOG_DEBUG("%s, message: gathering, this: %p", toLog(), this);
+      nice_agent_gather_candidates(agent_, 1);   
   }
 
   void NiceConnection::mainLoop() {
     //Start gathering candidates and fire event loop
-    ELOG_DEBUG("Starting g_ main_loop %p", this);
+    ELOG_DEBUG("%s, message: starting g_main_loop, this: %p", toLog(), this);
     if (agent_==NULL){
       return;
     }
     g_main_loop_run(loop_);
-    ELOG_DEBUG("Finished g_main_loop %p", this);
+    ELOG_DEBUG("%s, message: Finished g_main_loop, this: %p", toLog(), this);
   }
 
   bool NiceConnection::setRemoteCandidates(std::vector<CandidateInfo> &candidates, bool isBundle) {
@@ -259,7 +257,7 @@ namespace erizo {
       return false;
     }
     GSList* candList = NULL;
-    ELOG_DEBUG("Setting remote candidates %lu, mediatype %d", candidates.size(), this->mediaType);
+    ELOG_DEBUG("%s, message: setting remote candidates, candidate_size: %lu, mediatype: %d", toLog(), candidates.size(), this->mediaType);
 
     for (unsigned int it = 0; it < candidates.size(); it++) {
       NiceCandidateType nice_cand_type;
@@ -298,18 +296,12 @@ namespace erizo {
       if (cinfo.hostType == RELAY||cinfo.hostType==SRFLX){
         nice_address_set_from_string(&thecandidate->base_addr, cinfo.rAddress.c_str());
         nice_address_set_port(&thecandidate->base_addr, cinfo.rPort);
-        ELOG_DEBUG("Adding remote candidate type %d addr %s port %d raddr %s rport %d", cinfo.hostType, cinfo.hostAddress.c_str(), cinfo.hostPort,
-            cinfo.rAddress.c_str(), cinfo.rPort);
+        ELOG_DEBUG("%s, message: adding relay or srflx remote candidate, hostType: %d, hostAddress: %s, hostPort %d, rAddress: %s, rPort: %d", toLog(), cinfo.hostType, cinfo.hostAddress.c_str(), 
+            cinfo.hostPort, cinfo.rAddress.c_str(), cinfo.rPort);
       }else{
-        ELOG_DEBUG("Adding remote candidate type %d addr %s port %d priority %d componentId %d, username %s, pass %s", 
-            cinfo.hostType, 
-            cinfo.hostAddress.c_str(), 
-            cinfo.hostPort, 
-            cinfo.priority, 
-            cinfo.componentId,
-            cinfo.username.c_str(),
-            cinfo.password.c_str()
-            );
+        ELOG_DEBUG("%s, adding remote candidate, hostType: %d, hostAddress: %s, hostPort: %d, priority: %d, componentId: %d, ufrag: %s, pass: %s", 
+            toLog(), cinfo.hostType, cinfo.hostAddress.c_str(), cinfo.hostPort, cinfo.priority, cinfo.componentId, cinfo.username.c_str(),
+            cinfo.password.c_str());
       }
       candList = g_slist_prepend(candList, thecandidate);
     }
@@ -321,21 +313,17 @@ namespace erizo {
   }
 
   void NiceConnection::gatheringDone(uint stream_id){
-    ELOG_DEBUG("Gathering done for stream %u", stream_id);
+    ELOG_DEBUG("%s, message: gathering done, stream_id: %u", toLog(), stream_id);
     this->updateIceState(NICE_CANDIDATES_RECEIVED);
   }
 
   void NiceConnection::getCandidate(uint stream_id, uint component_id, const std::string &foundation) {
     GSList* lcands = nice_agent_get_local_candidates(agent_, stream_id, component_id);
     // We only want to get the new candidates
-    int listLength = g_slist_length(lcands);
-    ELOG_DEBUG("List length %u, candsDelivered %u", listLength, candsDelivered_);
     if (candsDelivered_ <= g_slist_length(lcands)){
       lcands = g_slist_nth(lcands, (candsDelivered_));
     }
-    ELOG_DEBUG("getCandidate %u", g_slist_length(lcands));
     for (GSList* iterator = lcands; iterator; iterator = iterator->next) {
-      ELOG_DEBUG("Candidate");
       char address[NICE_ADDRESS_STRING_LEN], baseAddress[NICE_ADDRESS_STRING_LEN];
       NiceCandidate *cand = (NiceCandidate*) iterator->data;
       nice_address_to_string(&cand->addr, address);
@@ -372,14 +360,7 @@ namespace erizo {
           break;
         case NICE_CANDIDATE_TYPE_RELAYED:
           char turnAddres[NICE_ADDRESS_STRING_LEN];
-          ELOG_DEBUG("TURN LOCAL CANDIDATE");
           nice_address_to_string(&cand->turn->server,turnAddres);
-          ELOG_DEBUG("address %s", address);
-          ELOG_DEBUG("baseAddress %s", baseAddress);
-          ELOG_DEBUG("stream_id %u", cand->stream_id);
-          ELOG_DEBUG("priority %u", cand->priority);
-          ELOG_DEBUG("TURN ADDRESS %s", turnAddres);
-
           cand_info.hostType = RELAY;
           cand_info.rAddress = std::string(baseAddress);
           cand_info.rPort = nice_address_get_port(&cand->base_addr);
@@ -407,7 +388,7 @@ namespace erizo {
   }
 
   void NiceConnection::setRemoteCredentials (const std::string& username, const std::string& password){
-    ELOG_DEBUG("Setting remote credentials %s, %s", username.c_str(), password.c_str());
+    ELOG_DEBUG("%s, message: setting remote credentials, ufrag: %s, pass: %s", toLog(), username.c_str(), password.c_str());
     nice_agent_set_remote_credentials(agent_, (guint) 1, username.c_str(), password.c_str());
   }
 
@@ -420,7 +401,7 @@ namespace erizo {
   }
 
   void NiceConnection::updateComponentState(unsigned int compId, IceState state) {
-    ELOG_DEBUG("%s - NICE Component State Changed %u - %u, total comps %u", transportName->c_str(), compId, state, iceComponents_);
+    ELOG_DEBUG("%s, message: new ice component state, newComponentState: %u, transport_name: %s, componentId %u, iceComponents: %u", toLog(), state, transportName->c_str(), compId, iceComponents_);
     comp_state_list_[compId] = state;
     if (state == NICE_READY) {
       for (unsigned int i = 1; i<=iceComponents_; i++) {
@@ -430,14 +411,14 @@ namespace erizo {
       }
     }else if (state == NICE_FAILED){
       if (receivedLastCandidate_){
-        ELOG_WARN("%s - NICE Component %u FAILED", transportName->c_str(), compId);
+        ELOG_WARN("%s, message: component failed, transport_name: %s, componentId: %u", toLog(), transportName->c_str(), compId);
         for (unsigned int i = 1; i<=iceComponents_; i++) {
           if (comp_state_list_[i] != NICE_FAILED) {
             return;
           }
         }
       }else{
-        ELOG_WARN("NICE FAIL but we haven't received all candidates");
+        ELOG_WARN("%s, message: not received all candidates, newComponentState:%u", toLog(), state);
         return;
       }
     }
@@ -452,17 +433,18 @@ namespace erizo {
 
     if(state <= iceState_) {
       if (state != NICE_READY)
-        ELOG_WARN("Unexpected change in iceState from %u to %u", iceState_, state);
+        ELOG_WARN("%s, message: unexpected ice state transition, iceState:%u  newIceState: %u", toLog(), iceState_, state);
       return;
     }
 
-    ELOG_INFO("%s - NICE State Changing from %u to %u %p", transportName->c_str(), this->iceState_, state, this);
+    ELOG_INFO("%s, message: iceState transition, transport_name: %s, iceState: %u, newIceState: %u, this: %p", toLog(), transportName->c_str(), 
+        this->iceState_, state, this);
     this->iceState_ = state;
     switch( iceState_) {
       case NICE_FINISHED:
         return;
       case NICE_FAILED:
-        ELOG_ERROR("Nice Failed, stopping ICE");
+        ELOG_WARN("%s, message: Ice Failed", toLog());
         break;
 
       case NICE_READY:
@@ -485,17 +467,17 @@ namespace erizo {
     nice_address_to_string(&local->addr, ipaddr);
     selectedPair.erizoCandidateIp = std::string(ipaddr);
     selectedPair.erizoCandidatePort = nice_address_get_port(&local->addr);
-    ELOG_INFO("Selected pair:\nlocal candidate addr: %s:%d",ipaddr, nice_address_get_port(&local->addr));
+    ELOG_DEBUG("%s, message: selected pair, local_addr: %s, local_port: %d", toLog(), ipaddr, nice_address_get_port(&local->addr));
     nice_address_to_string(&remote->addr, ipaddr);
     selectedPair.clientCandidateIp = std::string(ipaddr);
     selectedPair.clientCandidatePort = nice_address_get_port(&remote->addr);
-    ELOG_INFO("remote candidate addr: %s:%d",ipaddr, nice_address_get_port(&remote->addr));
+    ELOG_INFO("%s, message: selected pair, remote_addr: %s, remote_port: %d", toLog(), ipaddr, nice_address_get_port(&remote->addr));
     return selectedPair;
 
   }
 
   void NiceConnection::setReceivedLastCandidate(bool hasReceived){
-    ELOG_DEBUG("Setting hasReceivedLastCandidate %u", hasReceived);
+    ELOG_DEBUG("%s, message: setting hasReceivedLastCandidate, hasReceived: %u", toLog(), hasReceived);
     this->receivedLastCandidate_ = hasReceived;
   }
 } /* namespace erizo */

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -102,7 +102,7 @@ namespace erizo {
      * @param transportName The name of the transport protocol. Was used when WebRTC used video_rtp instead of just rtp.
      * @param iceComponents Number of ice components pero connection. Default is 1 (rtcp-mux).
      */
-    NiceConnection(MediaType med, const std::string &transportName, NiceConnectionListener* listener, unsigned int iceComponents,
+    NiceConnection(MediaType med, const std::string &transportName, const std::string& connection_id, NiceConnectionListener* listener, unsigned int iceComponents,
         const IceConfig& iceConfig, std::string username = "", std::string password = "");
 
     virtual ~NiceConnection();
@@ -167,7 +167,7 @@ namespace erizo {
     void close();
 
     private:
-    void mainLoop();
+    std::string connection_id_;
     NiceAgent* agent_;
     GMainContext* context_;
     GMainLoop* loop_;
@@ -186,6 +186,12 @@ namespace erizo {
     std::string ufrag_, upass_, username_, password_;
     IceConfig iceConfig_;
     bool receivedLastCandidate_;
+    
+    void mainLoop();
+    
+    inline const char* toLog() {
+      return (std::string("id: ")+connection_id_).c_str();
+    };
   };
 
 } /* namespace erizo */

--- a/erizo/src/erizo/Transport.h
+++ b/erizo/src/erizo/Transport.h
@@ -27,11 +27,11 @@ namespace erizo {
       boost::shared_ptr<NiceConnection> nice_;
       MediaType mediaType;
       std::string transport_name;
-      Transport(MediaType med, const std::string &transport_name, bool bundle, bool rtcp_mux, TransportListener *transportListener, const IceConfig& iceConfig) :
-        mediaType(med), transport_name(transport_name),rtcp_mux_(rtcp_mux), transpListener_(transportListener), state_(TRANSPORT_INITIAL), iceConfig_(iceConfig), bundle_(bundle)
-      {
-      }
-      virtual ~Transport(){}
+      Transport(MediaType med, const std::string& transport_name, const std::string& connection_id, bool bundle, 
+          bool rtcp_mux, TransportListener *transportListener, const IceConfig& iceConfig) :
+        mediaType(med), transport_name(transport_name), rtcp_mux_(rtcp_mux), transpListener_(transportListener),
+        connection_id_(connection_id), state_(TRANSPORT_INITIAL), iceConfig_(iceConfig), bundle_(bundle) {};
+      virtual ~Transport() {};
       virtual void updateIceState(IceState state, NiceConnection *conn) = 0;
       virtual void onNiceData(unsigned int component_id, char* data, int len, NiceConnection* nice) = 0;
       virtual void onCandidate(const CandidateInfo &candidate, NiceConnection *conn)=0;
@@ -45,10 +45,10 @@ namespace erizo {
       }
       TransportListener* getTransportListener() {
         return transpListener_;
-      }
+      };
       TransportState getTransportState() {
         return state_;
-      }
+      };
       void updateTransportState(TransportState state) {
         if (state == state_) {
           return;
@@ -57,18 +57,19 @@ namespace erizo {
         if (transpListener_ != NULL) {
           transpListener_->updateState(state, this);
         }
-      }
+      };
       void writeOnNice(int comp, void* buf, int len) {
         nice_->sendData(comp, buf, len);
-      }
+      };
       bool setRemoteCandidates(std::vector<CandidateInfo> &candidates, bool isBundle) {
         return nice_->setRemoteCandidates(candidates, isBundle);
-      }
+      };
       bool rtcp_mux_;
     private:
       TransportListener *transpListener_;
 
     protected:
+      std::string connection_id_;
       TransportState state_;
       IceConfig iceConfig_;
       bool bundle_;

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -82,7 +82,7 @@ namespace erizo {
     videoEnabled_ = true;
     audioEnabled_ = true;
     this->localSdp_.createOfferSdp(videoEnabled_, audioEnabled_);
-    ELOG_DEBUG("%s, message:Creating sdp offer, isBundle: %d", toLog(), bundle_);
+    ELOG_DEBUG("%s, message: Creating sdp offer, isBundle: %d", toLog(), bundle_);
     if (videoEnabled_)
       localSdp_.videoSsrc = this->getVideoSinkSSRC();
     if (audioEnabled_)
@@ -442,7 +442,7 @@ namespace erizo {
           parseIncomingPayloadType(buf, len, AUDIO_PACKET);
           audioSink_->deliverAudioData(buf, len);
         } else {
-          ELOG_DEBUG("%s unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
+          ELOG_DEBUG("%s, unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
         }
       } else{ 
         if (transport->mediaType == AUDIO_TYPE) {
@@ -450,7 +450,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, AUDIO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getAudioSourceSSRC() == 0) {
-              ELOG_DEBUG("%s discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
+              ELOG_DEBUG("%s, discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
               this->setAudioSourceSSRC(recvSSRC);
             }
             audioSink_->deliverAudioData(buf, len);
@@ -460,7 +460,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, VIDEO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getVideoSourceSSRC() == 0) {
-              ELOG_DEBUG("%s discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
+              ELOG_DEBUG("%s, discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
               this->setVideoSourceSSRC(recvSSRC);
             }
             // change ssrc for RTP packets, don't touch here if RTCP
@@ -560,7 +560,7 @@ namespace erizo {
         cond_.notify_one();
         break;
       default:
-        ELOG_DEBUG("%s, message: Unacted on state, state %d", toLog(), state);
+        ELOG_DEBUG("%s, message: Doing nothing on state, state %d", toLog(), state);
         break;
     }
 
@@ -580,7 +580,7 @@ namespace erizo {
     globalState_ = temp;
 
     if (connEventListener_ != NULL) {
-      ELOG_INFO("%s, newGlobalState:%d", toLog(), globalState_);
+      ELOG_INFO("%s, newGlobalState: %d", toLog(), globalState_);
       connEventListener_->notifyEvent(globalState_, msg);
     }
   }

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -213,7 +213,7 @@ namespace erizo {
       } else if (theType==AUDIO_TYPE){
         res = audioTransport_->setRemoteCandidates(tempSdp.getCandidateInfos(), bundle_);
       }else{
-        ELOG_ERROR("%s msg:Cannot add remote candidate with no Media (video or audio), candidate: %s", toLog(), sdp.c_str() );
+        ELOG_ERROR("%s, message: add remote candidate with no Media (video or audio), candidate: %s", toLog(), sdp.c_str() );
       }
     }
 
@@ -224,7 +224,7 @@ namespace erizo {
   }
 
   std::string WebRtcConnection::getLocalSdp() {
-    ELOG_DEBUG("%s Getting Local Sdp", toLog());
+    ELOG_DEBUG("%s, message: Getting Local Sdp", toLog());
     if (videoTransport_ != NULL) {
       videoTransport_->processLocalSdp(&localSdp_);
     }
@@ -258,7 +258,7 @@ namespace erizo {
 
   void WebRtcConnection::onCandidate(const CandidateInfo& cand, Transport *transport) {
     std::string sdp = localSdp_.addCandidate(cand);
-    ELOG_DEBUG("%s, message: Discovered New Candidate, Candidate: %s", toLog(), sdp.c_str());
+    ELOG_DEBUG("%s, message: Discovered New Candidate, candidate: %s", toLog(), sdp.c_str());
     if(trickleEnabled_){
       if (connEventListener_ != NULL) {
         if (!bundle_) {
@@ -368,7 +368,7 @@ namespace erizo {
         }
 
       } else {
-        ELOG_DEBUG("%s, Unknown SSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
+        ELOG_DEBUG("%s, unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
       }
       return newLength;
     }
@@ -442,7 +442,7 @@ namespace erizo {
           parseIncomingPayloadType(buf, len, AUDIO_PACKET);
           audioSink_->deliverAudioData(buf, len);
         } else {
-          ELOG_DEBUG("%s Unknown SSRC: %u localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
+          ELOG_DEBUG("%s unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
         }
       } else{ 
         if (transport->mediaType == AUDIO_TYPE) {
@@ -450,7 +450,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, AUDIO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getAudioSourceSSRC() == 0) {
-              ELOG_DEBUG("%s Discovered Audio Source SSRC:%u", toLog(), recvSSRC);
+              ELOG_DEBUG("%s discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
               this->setAudioSourceSSRC(recvSSRC);
             }
             audioSink_->deliverAudioData(buf, len);
@@ -460,7 +460,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, VIDEO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getVideoSourceSSRC() == 0) {
-              ELOG_DEBUG("%s Discovered Video Source SSRC:%u", toLog(), recvSSRC);
+              ELOG_DEBUG("%s discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
               this->setVideoSourceSSRC(recvSSRC);
             }
             // change ssrc for RTP packets, don't touch here if RTCP
@@ -493,7 +493,7 @@ namespace erizo {
     boost::mutex::scoped_lock lock(updateStateMutex_);
     WebRTCEvent temp = globalState_;
     std::string msg = "";
-    ELOG_DEBUG("%s, transport_name: %s new_state: %d", toLog(), transport->transport_name.c_str(), state);
+    ELOG_DEBUG("%s, transportName: %s, new_state: %d", toLog(), transport->transport_name.c_str(), state);
     if (videoTransport_.get() == NULL && audioTransport_.get() == NULL) {
       ELOG_ERROR("%s, message: Updating NULL transport, state: %d", toLog(), state);
       return;
@@ -565,7 +565,7 @@ namespace erizo {
     }
 
     if (audioTransport_.get() != NULL && videoTransport_.get() != NULL) {
-      ELOG_DEBUG("%s, message: Update Transport State, transport_name: %s, videoTransportState: %d, audioTransportState: %d, calculatedState: %d, globalState: %d", 
+      ELOG_DEBUG("%s, message: Update Transport State, transportName: %s, videoTransportState: %d, audioTransportState: %d, calculatedState: %d, globalState: %d", 
         toLog(),
         transport->transport_name.c_str(),
         (int)audioTransport_->getTransportState(), 
@@ -622,7 +622,7 @@ namespace erizo {
   }
 
   void WebRtcConnection::setSlideShowMode (bool state){
-    ELOG_DEBUG("%s, SlideShowMode: %u", toLog(), state);
+    ELOG_DEBUG("%s, slideShowMode: %u", toLog(), state);
     if (slideShowMode_==state){
       return;
     }
@@ -634,7 +634,7 @@ namespace erizo {
       ELOG_DEBUG("%s, message: Setting seqNo, seqNo: %u", toLog(), seqNo_);
     }else{
       seqNoOffset_ = sendSeqNo_ - seqNo_ + 1;
-      ELOG_DEBUG("%s, message: Changing offset manually, sendSeqNo %u, seqNo %u, offset %u", toLog(), sendSeqNo_, seqNo_, seqNoOffset_);
+      ELOG_DEBUG("%s, message: Changing offset manually, sendSeqNo: %u, seqNo: %u, offset: %u", toLog(), sendSeqNo_, seqNo_, seqNoOffset_);
       slideShowMode_ = false;
       shouldSendFeedback_ = true;
     }

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -15,10 +15,11 @@
 namespace erizo {
   DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
   
-  WebRtcConnection::WebRtcConnection(std::string wrtcId, bool audioEnabled, bool videoEnabled, 
+  WebRtcConnection::WebRtcConnection(const std::string& connection_id, bool audioEnabled, bool videoEnabled, 
       const IceConfig& iceConfig, WebRtcConnectionEventListener* listener)
-      : wrtcId_ (wrtcId), audioEnabled_ (audioEnabled), videoEnabled_(videoEnabled),connEventListener_(listener), iceConfig_(iceConfig), fec_receiver_(this){
-    ELOG_INFO("WebRtcConnection constructor stunserver %s stunPort %d minPort %d maxPort %d, id %s", iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort, wrtcId_.c_str());
+      : connection_id_ (connection_id), audioEnabled_ (audioEnabled), videoEnabled_(videoEnabled),connEventListener_(listener), iceConfig_(iceConfig), fec_receiver_(this){
+    ELOG_INFO("%s, message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d", 
+        toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort); 
     bundle_ = false;
     setVideoSinkSSRC(55543);
     setAudioSinkSSRC(44444);
@@ -45,7 +46,7 @@ namespace erizo {
   }
 
   WebRtcConnection::~WebRtcConnection() {
-    ELOG_INFO("WebRtcConnection Destructor");
+    ELOG_DEBUG("%s, message:Destructor called", toLog());
     sending_ = false;
     cond_.notify_one();
     send_Thread_.join();
@@ -62,7 +63,7 @@ namespace erizo {
     videoSink_ = NULL;
     audioSink_ = NULL;
     fbSink_ = NULL;
-    ELOG_INFO("WebRtcConnection Destructor END");
+    ELOG_DEBUG("%s, message: Destructor ended", toLog());
   }
 
   bool WebRtcConnection::init() {
@@ -81,27 +82,22 @@ namespace erizo {
     videoEnabled_ = true;
     audioEnabled_ = true;
     this->localSdp_.createOfferSdp(videoEnabled_, audioEnabled_);
-
-    ELOG_DEBUG("Creating sdp offer");
-    ELOG_DEBUG("Setting SSRC to localSdp %u", this->getVideoSinkSSRC());
+    ELOG_DEBUG("%s, message:Creating sdp offer, isBundle: %d", toLog(), bundle_);
     if (videoEnabled_)
       localSdp_.videoSsrc = this->getVideoSinkSSRC();
     if (audioEnabled_)
       localSdp_.audioSsrc = this->getAudioSinkSSRC();
 
     if (bundle_){
-      ELOG_DEBUG("Creating Bundle Offer");
-      videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", bundle_, true, this, iceConfig_ , "", "", true));
+      videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", connection_id_, bundle_, true, this, iceConfig_ , "", "", true));
       videoTransport_->start();
     }else{
       if (videoTransport_.get()==NULL && videoEnabled_){ // For now we don't re/check transports, if they are already created we leave them there
-        ELOG_DEBUG("Creating Video transport for Offer");
-        videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", bundle_, true, this, iceConfig_ , "", "", true));
+        videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", connection_id_, bundle_, true, this, iceConfig_ , "", "", true));
         videoTransport_->start();
       }
       if (audioTransport_.get()==NULL && audioEnabled_){
-        ELOG_DEBUG("Creating Audio transport for Offer");
-        audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", bundle_, true, this, iceConfig_, "","", true));
+        audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", connection_id_, bundle_, true, this, iceConfig_, "","", true));
         audioTransport_->start();
       }
     }
@@ -113,16 +109,13 @@ namespace erizo {
   }
 
   bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
-    ELOG_DEBUG("Set Remote SDP %s", sdp.c_str());
+    ELOG_DEBUG("%s, message: setting remote SDP", toLog());
     remoteSdp_.initWithSdp(sdp, "");
 
     bundle_ = remoteSdp_.isBundle;
     localSdp_.setOfferSdp(remoteSdp_);
     extProcessor_.setSdpInfo(localSdp_);
         
-    ELOG_DEBUG("Video %d videossrc %u Audio %d audio ssrc %u Bundle %d", remoteSdp_.hasVideo, remoteSdp_.videoSsrc, remoteSdp_.hasAudio, remoteSdp_.audioSsrc,  bundle_);
-    ELOG_DEBUG("Setting SSRC to localSdp %u", this->getVideoSinkSSRC());
-
     localSdp_.videoSsrc = this->getVideoSinkSSRC();
     localSdp_.audioSsrc = this->getAudioSinkSSRC();
 
@@ -141,11 +134,11 @@ namespace erizo {
           std::string username, password;
           remoteSdp_.getCredentials(username, password, VIDEO_TYPE);
           if (videoTransport_.get()==NULL){
-            ELOG_DEBUG("Creating videoTransport with creds %s, %s", username.c_str(), password.c_str());
-            videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", bundle_, remoteSdp_.isRtcpMux, this, iceConfig_ , username, password, false));
+            ELOG_DEBUG("%s, message: Creating videoTransport, ufrag: %s, pass: %s", toLog(), username.c_str(), password.c_str());
+            videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", connection_id_, bundle_, remoteSdp_.isRtcpMux, this, iceConfig_ , username, password, false));
             videoTransport_->start();
           }else{ 
-            ELOG_DEBUG("UPDATING videoTransport with creds %s, %s", username.c_str(), password.c_str());
+            ELOG_DEBUG("%s, message: Updating videoTransport, ufrag: %s, pass: %s", toLog(), username.c_str(), password.c_str());
             videoTransport_->getNiceConnection()->setRemoteCredentials(username, password);
           }
         }
@@ -153,11 +146,11 @@ namespace erizo {
           std::string username, password;
           remoteSdp_.getCredentials(username, password, AUDIO_TYPE);
           if (audioTransport_.get()==NULL){
-            ELOG_DEBUG("Creating audioTransport with creds %s, %s", username.c_str(), password.c_str());
-            audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", bundle_, remoteSdp_.isRtcpMux, this, iceConfig_, username, password, false));
+            ELOG_DEBUG("%s, message: Creating audioTransport, ufrag: %s, pass: %s", toLog(), username.c_str(), password.c_str());
+            audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", connection_id_, bundle_, remoteSdp_.isRtcpMux, this, iceConfig_, username, password, false));
             audioTransport_->start();
           }else{
-            ELOG_DEBUG("UPDATING audioTransport with creds %s, %s", username.c_str(), password.c_str());
+            ELOG_DEBUG("%s, message: Update audioTransport, ufrag: %s, pass: %s", toLog(), username.c_str(), password.c_str());
             audioTransport_->getNiceConnection()->setRemoteCredentials(username, password);
           }
 
@@ -166,7 +159,7 @@ namespace erizo {
     }
     if (this->getCurrentState()>=CONN_GATHERED){
       if (!remoteSdp_.getCandidateInfos().empty()){
-        ELOG_DEBUG("There are candidate in the remote SDP and we are GATHERED: Setting Remote Candidates");
+        ELOG_DEBUG("%s, message: Setting remote candidates after gathered", toLog());
         if (remoteSdp_.hasVideo) {
           videoTransport_->setRemoteCandidates(remoteSdp_.getCandidateInfos(), bundle_);
         }
@@ -185,7 +178,7 @@ namespace erizo {
 
 
     if (remoteSdp_.videoBandwidth !=0){
-      ELOG_DEBUG("Setting remote bandwidth %u", remoteSdp_.videoBandwidth);
+      ELOG_DEBUG("%s, message: Setting remote BW, maxVideoBW: %u", toLog(), remoteSdp_.videoBandwidth);
       this->rtcpProcessor_->setMaxVideoBW(remoteSdp_.videoBandwidth*1000);
     }
 
@@ -194,12 +187,12 @@ namespace erizo {
 
   bool WebRtcConnection::addRemoteCandidate(const std::string &mid, int mLineIndex, const std::string &sdp) {
     // TODO Check type of transport.
-    ELOG_DEBUG("Adding remote Candidate %s, mid %s, sdpMLine %d",sdp.c_str(), mid.c_str(), mLineIndex);
+    ELOG_DEBUG("%s, message: Adding remote Candidate, candidate: %s, mid: %s, sdpMLine: %d", toLog(), sdp.c_str(), mid.c_str(), mLineIndex);
     MediaType theType;
     std::string theMid;
     // Checking if it's the last candidate, only works in bundle.
     if (mLineIndex == -1){ 
-      ELOG_DEBUG("All candidates received");
+      ELOG_DEBUG("%s, message: All candidates received", toLog());
       videoTransport_->getNiceConnection()->setReceivedLastCandidate(true);
     }
     if ((!mid.compare("video"))||(mLineIndex ==remoteSdp_.videoSdpMLine)){
@@ -216,13 +209,11 @@ namespace erizo {
     bool res = false;
     if(tempSdp.initWithSdp(sdp, theMid)){
       if (theType == VIDEO_TYPE||bundle_){
-        ELOG_DEBUG("Setting VIDEO CANDIDATE" );
         res = videoTransport_->setRemoteCandidates(tempSdp.getCandidateInfos(), bundle_);
       } else if (theType==AUDIO_TYPE){
-        ELOG_DEBUG("Setting AUDIO CANDIDATE");
         res = audioTransport_->setRemoteCandidates(tempSdp.getCandidateInfos(), bundle_);
       }else{
-        ELOG_ERROR("Cannot add remote candidate with no Media (video or audio)");
+        ELOG_ERROR("%s msg:Cannot add remote candidate with no Media (video or audio), candidate: %s", toLog(), sdp.c_str() );
       }
     }
 
@@ -233,7 +224,7 @@ namespace erizo {
   }
 
   std::string WebRtcConnection::getLocalSdp() {
-    ELOG_DEBUG("Getting SDP");
+    ELOG_DEBUG("%s Getting Local Sdp", toLog());
     if (videoTransport_ != NULL) {
       videoTransport_->processLocalSdp(&localSdp_);
     }
@@ -267,7 +258,7 @@ namespace erizo {
 
   void WebRtcConnection::onCandidate(const CandidateInfo& cand, Transport *transport) {
     std::string sdp = localSdp_.addCandidate(cand);
-    ELOG_DEBUG("On Candidate %s", sdp.c_str());
+    ELOG_DEBUG("%s, message: Discovered New Candidate, Candidate: %s", toLog(), sdp.c_str());
     if(trickleEnabled_){
       if (connEventListener_ != NULL) {
         if (!bundle_) {
@@ -377,7 +368,7 @@ namespace erizo {
         }
 
       } else {
-        ELOG_WARN("Unknown SSRC %u, localVideo %u, remoteVideo %u, ignoring", recvSSRC, this->getVideoSourceSSRC(), this->getVideoSinkSSRC());
+        ELOG_DEBUG("%s, Unknown SSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
       }
       return newLength;
     }
@@ -423,7 +414,7 @@ namespace erizo {
             switch(chead->packettype){
               case RTCP_Receiver_PT:
                 if ((chead->getHighestSeqnum() + seqNoOffset_) < chead->getHighestSeqnum()){
-                  ELOG_DEBUG("The seqNo adjustment causes a wraparound, add to cycles");
+                  //The seqNo adjustment causes a wraparound, add to cycles
                   chead->setSeqnumCycles(chead->getSeqnumCycles()+1);
                 }
                 chead->setHighestSeqnum(chead->getHighestSeqnum()+seqNoOffset_);
@@ -451,7 +442,7 @@ namespace erizo {
           parseIncomingPayloadType(buf, len, AUDIO_PACKET);
           audioSink_->deliverAudioData(buf, len);
         } else {
-          ELOG_WARN("Unknown SSRC %u, localVideo %u, remoteVideo %u, ignoring", recvSSRC, this->getVideoSourceSSRC(), this->getVideoSinkSSRC());
+          ELOG_DEBUG("%s Unknown SSRC: %u localVideoSSRC: %u, localAudioSSRC: %u", toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
         }
       } else{ 
         if (transport->mediaType == AUDIO_TYPE) {
@@ -459,7 +450,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, AUDIO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getAudioSourceSSRC() == 0) {
-              ELOG_DEBUG("Audio Source SSRC is %u", recvSSRC);
+              ELOG_DEBUG("%s Discovered Audio Source SSRC:%u", toLog(), recvSSRC);
               this->setAudioSourceSSRC(recvSSRC);
             }
             audioSink_->deliverAudioData(buf, len);
@@ -469,7 +460,7 @@ namespace erizo {
             parseIncomingPayloadType(buf, len, VIDEO_PACKET);
             // Firefox does not send SSRC in SDP
             if (this->getVideoSourceSSRC() == 0) {
-              ELOG_DEBUG("Video Source SSRC is %u", recvSSRC);
+              ELOG_DEBUG("%s Discovered Video Source SSRC:%u", toLog(), recvSSRC);
               this->setVideoSourceSSRC(recvSSRC);
             }
             // change ssrc for RTP packets, don't touch here if RTCP
@@ -502,9 +493,9 @@ namespace erizo {
     boost::mutex::scoped_lock lock(updateStateMutex_);
     WebRTCEvent temp = globalState_;
     std::string msg = "";
-    ELOG_INFO("Update Transport State %s to %d", transport->transport_name.c_str(), state);
+    ELOG_DEBUG("%s, transport_name: %s new_state: %d", toLog(), transport->transport_name.c_str(), state);
     if (videoTransport_.get() == NULL && audioTransport_.get() == NULL) {
-      ELOG_ERROR("Update Transport State with Transport NULL, this should not happen!");
+      ELOG_ERROR("%s, message: Updating NULL transport, state: %d", toLog(), state);
       return;
     }
     if (globalState_ == CONN_FAILED) {
@@ -526,7 +517,7 @@ namespace erizo {
       case TRANSPORT_GATHERED:
         if (bundle_){
           if (!remoteSdp_.getCandidateInfos().empty()){
-            ELOG_DEBUG("There are candidates in the SDP that could not be passed before, passing them now");
+            //Passing now new candidates that could not be passed before
             if (remoteSdp_.hasVideo) {
               videoTransport_->setRemoteCandidates(remoteSdp_.getCandidateInfos(), bundle_);
             }
@@ -565,21 +556,20 @@ namespace erizo {
         temp = CONN_FAILED;
         sending_ = false;
         msg = remoteSdp_.getSdp();
-        ELOG_ERROR("WebRtcConnection failed, stopping sending. Possibly ICE Connection Failure");
+        ELOG_ERROR("%s, message: Transport Failed, transportType: %s", toLog(), transport->transport_name.c_str() );
         cond_.notify_one();
         break;
       default:
-        ELOG_DEBUG("New state %d", state);
+        ELOG_DEBUG("%s, message: Unacted on state, state %d", toLog(), state);
         break;
     }
 
     if (audioTransport_.get() != NULL && videoTransport_.get() != NULL) {
-      ELOG_INFO("%s - Update Transport State end, %d - %d, %d - %d, %d - %d", 
+      ELOG_DEBUG("%s, message: Update Transport State, transport_name: %s, videoTransportState: %d, audioTransportState: %d, calculatedState: %d, globalState: %d", 
+        toLog(),
         transport->transport_name.c_str(),
         (int)audioTransport_->getTransportState(), 
         (int)videoTransport_->getTransportState(), 
-        this->getAudioSourceSSRC(),
-        this->getVideoSourceSSRC(),
         (int)temp, 
         (int)globalState_);
     }
@@ -590,6 +580,7 @@ namespace erizo {
     globalState_ = temp;
 
     if (connEventListener_ != NULL) {
+      ELOG_INFO("%s, newGlobalState:%d", toLog(), globalState_);
       connEventListener_->notifyEvent(globalState_, msg);
     }
   }
@@ -625,13 +616,13 @@ namespace erizo {
       }
       sendQueue_.push(p_);
     }else{
-      ELOG_DEBUG("Discarding Packets");
+      ELOG_WARN("%s, message: Queue Discarding packets", toLog());
     }
     cond_.notify_one();
   }
 
   void WebRtcConnection::setSlideShowMode (bool state){
-    ELOG_DEBUG("Setting SlideShowMode %u", state);
+    ELOG_DEBUG("%s, SlideShowMode: %u", toLog(), state);
     if (slideShowMode_==state){
       return;
     }
@@ -640,10 +631,10 @@ namespace erizo {
       grace_ = 0;
       slideShowMode_ = true;
       shouldSendFeedback_ = false;
-      ELOG_DEBUG("Setting seqNo %u", seqNo_);
+      ELOG_DEBUG("%s, message: Setting seqNo, seqNo: %u", toLog(), seqNo_);
     }else{
       seqNoOffset_ = sendSeqNo_ - seqNo_ + 1;
-      ELOG_DEBUG("Changing offset manually, sendSeqNo %u, seqNo %u, offset %u", sendSeqNo_, seqNo_, seqNoOffset_);
+      ELOG_DEBUG("%s, message: Changing offset manually, sendSeqNo %u, seqNo %u, offset %u", toLog(), sendSeqNo_, seqNo_, seqNoOffset_);
       slideShowMode_ = false;
       shouldSendFeedback_ = true;
     }
@@ -710,7 +701,7 @@ namespace erizo {
               }
               if(sendQueue_.front().comp ==-1){
                   sending_ =  false;
-                  ELOG_DEBUG("Finishing send Thread, packet -1");
+                  ELOG_DEBUG("%s, message: finishing send Thread", toLog());
                   sendQueue_.pop();
                   return;
               }

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -61,7 +61,7 @@ public:
      * Constructor.
      * Constructs an empty WebRTCConnection without any configuration.
      */
-    WebRtcConnection(const std::string wrtcId, bool audioEnabled, bool videoEnabled, const IceConfig& iceConfig, WebRtcConnectionEventListener* listener);
+    WebRtcConnection(const std::string& connection_id, bool audioEnabled, bool videoEnabled, const IceConfig& iceConfig, WebRtcConnectionEventListener* listener);
     /**
      * Destructor.
      */
@@ -149,7 +149,7 @@ public:
 
 private:
   
-    std::string wrtcId_;
+    std::string connection_id_;
     SdpInfo remoteSdp_;
     SdpInfo localSdp_;
     bool audioEnabled_;
@@ -188,6 +188,10 @@ private:
     int deliverAudioData_(char* buf, int len);
     int deliverVideoData_(char* buf, int len);
     int deliverFeedback_(char* buf, int len);
+
+    inline const char* toLog() {
+      return (std::string("id: ")+connection_id_).c_str();
+    };
 
     //Utils
     std::string getJSONCandidate(const std::string& mid, const std::string& sdp);

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -7,7 +7,7 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 # Print the date in ISO 8601 format
-log4j.appender.A1.layout.ConversionPattern=%d  - %p: %c - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d  - %p [%t] %c - %m%n
 
 log4j.logger.DtlsTransport=DEBUG
 log4j.logger.NiceConnection=DEBUG


### PR DESCRIPTION
WebRtcConnection, NiceConnection and DtlsTransport logs now include a connection identifier.
Logs are a bit cleaner now, with a more unified format in these 3 classes.
OneToMany logs will be introduced in another PR