### PR TITLE
Fixed error and memory leak when unpublishing an ExternalInput

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -209,7 +209,7 @@ exports.ErizoJSController = function (spec) {
 
             ei.wrtcId = eiId;
 
-            publishers[from] = {muxer: muxer};
+            publishers[from] = {muxer: muxer, wrtc: ei};
             subscribers[from] = {};
 
             ei.setAudioReceiver(muxer);
@@ -382,7 +382,6 @@ exports.ErizoJSController = function (spec) {
                     subscribers[from][key].close();
                 }
             }
-            publishers[from].wrtc.close();
             publishers[from].muxer.close(function(message){
                 log.info("message: muxer closed succesfully, id: " + from + ", muxerMessage:", message);
                 delete subscribers[from];

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -411,7 +411,6 @@ exports.ErizoJSController = function (spec) {
 
         if (subscribers[to][from]) {
             log.info("message: removing subscriber, id: " + subscribers[to][from].wrtcId);
-            subscribers[to][from].close();
             publishers[to].muxer.removeSubscriber(from);
             delete subscribers[to][from];
         }


### PR DESCRIPTION
Also, there's no need to close both the publisher and the muxer as the muxer takes care of everything. We could consider changing the way that works but this is the consistent way to do it. 