### PR TITLE
Resender now works directly through the DtlsTransport and has a max amount of resends

### DIFF
--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -334,7 +334,7 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
 
     void DtlsSocketContext::write(const unsigned char* data, unsigned int len) {
       if (receiver != NULL) {
-        receiver->writeDtls(this, data, len);
+        receiver->onDtlsPacket(this, data, len);
       }
     }
 

--- a/erizo/src/erizo/dtls/DtlsSocket.h
+++ b/erizo/src/erizo/dtls/DtlsSocket.h
@@ -138,7 +138,7 @@ class DtlsSocket {
 
 class DtlsReceiver {
  public:
-  virtual void writeDtls(DtlsSocketContext *ctx, const unsigned char* data, unsigned int len) = 0;
+  virtual void onDtlsPacket(DtlsSocketContext *ctx, const unsigned char* data, unsigned int len) = 0;
   virtual void onHandshakeCompleted(DtlsSocketContext *ctx, std::string clientKey, std::string serverKey,
                                     std::string srtp_profile) = 0;
   virtual void onHandshakeFailed(DtlsSocketContext *ctx, const std::string error) = 0;


### PR DESCRIPTION
Changed Resender to make it easier to send multiple resends with the same object and set a limit for the max amount of resends. Going over that limit will trigger a TRANSPORT_FAIL