### PR TITLE
Fixed Nuve crash because of missing callback

### DIFF
--- a/nuve/nuveAPI/rpc/rpc.js
+++ b/nuve/nuveAPI/rpc/rpc.js
@@ -60,7 +60,9 @@ exports.connect = function (callback) {
                       });
 
                   });
-                  callback();
+                  if (callback) {
+                      callback();
+                  }
               });
             };
 


### PR DESCRIPTION
A new callback was introduced in PR #567, this broke nuve.js