### PR TITLE
Fix/minor cometic fixes: media config file to gitignore and compilation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ erizo_controller/erizoAgent/erizo-*.log
 .cproject
 spine/erizofc.js
 extras/basic_example/public/assets/
+rtp_media_config.js

--- a/erizo/src/test/NiceConnectionTest.cpp
+++ b/erizo/src/test/NiceConnectionTest.cpp
@@ -343,13 +343,13 @@ TEST_F(NiceConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Ready
   nice_connection->updateIceState(erizo::NICE_READY);
   nice_connection->queueData(0, test_packet, sizeof(test_packet));
   erizo::packetPtr packet = nice_connection->getPacket();
-  EXPECT_EQ(packet->length, sizeof(test_packet));
+  EXPECT_EQ(static_cast<unsigned int>(packet->length), sizeof(test_packet));
   EXPECT_EQ(0, strcmp(test_packet, packet->data));
 }
 
 TEST_F(NiceConnectionTest, sendData_Succeed_When_Ice_Ready) {
   const unsigned int kCompId = 1;
-  const unsigned int kLength = sizeof(test_packet);
+  const int kLength = sizeof(test_packet);
 
   EXPECT_CALL(*nice_listener, updateIceState(erizo::NICE_READY , _)).Times(1);
   nice_connection->updateIceState(erizo::NICE_READY);

--- a/erizo/src/test/PacketTest.cpp
+++ b/erizo/src/test/PacketTest.cpp
@@ -132,7 +132,7 @@ TEST(erizoPacket, rtpPacketQueueDoesNotPushSampleLessThanWhatHasBeenPopped) {
 }
 
 TEST(erizoPacket, rtpPacketQueueMakesDataAvailableOnceEnoughSamplesPushed) {
-    unsigned int max = 10, depth = 5;
+    int max = 10, depth = 5;
     erizo::RtpPacketQueue queue(depth, max);  // max and depth.
     queue.setTimebase(1);
 
@@ -160,10 +160,9 @@ TEST(erizoPacket, rtpPacketQueueMakesDataAvailableOnceEnoughSamplesPushed) {
 }
 
 TEST(erizoPacket, rtpPacketQueueRespectsMax) {
-    unsigned int max = 10, depth = 5;
+    int max = 10, depth = 5;
     erizo::RtpPacketQueue queue(depth, max);  // max and depth.
     queue.setTimebase(1);   // dummy timebase.
-    uint16_t x = 0;
 
     // let's push ten times the max.
     for (uint16_t x = 0; x < (max * 10); x++) {
@@ -202,7 +201,7 @@ TEST(erizoPacket, depthCalculationHandlesTimestampWrap) {
     // In the RTP spec, timestamps for a packet are 32 bit unsigned,
     // and can overflow (very possible given that the starting
     // point is random.  Test that our depth works correctly
-    unsigned int max = 10, depth = 5;
+    int max = 10, depth = 5;
     erizo::RtpPacketQueue queue(depth, max);  // max and depth.
     queue.setTimebase(1);   // dummy timebase.
 


### PR DESCRIPTION
Just a couple of minor fixes that should make Licode life cleaner