### PR TITLE
Add the possibity to include metadata in the logs

### DIFF
--- a/erizo/src/erizo/DtlsTransport.h
+++ b/erizo/src/erizo/DtlsTransport.h
@@ -56,9 +56,6 @@ class DtlsTransport : dtls::DtlsReceiver, public Transport {
   const unsigned int kSecsPerResend = 3;
 
   void getNiceDataLoop();
-  inline const char* toLog() {
-    return (std::string("id: ")+connection_id_).c_str();
-  }
 };
 
 class Resender {

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -81,7 +81,7 @@ class NiceConnectionListener {
  * Represents an ICE Connection in an new thread.
  *
  */
-class NiceConnection {
+class NiceConnection : public LogContext {
   DECLARE_LOGGER();
 
  public:
@@ -198,7 +198,7 @@ class NiceConnection {
   void mainLoop();
 
   inline const char* toLog() {
-    return (std::string("id: ")+connection_id_).c_str();
+    return ("id: " + connection_id_ + ", " + printLogContext()).c_str();
   }
 };
 

--- a/erizo/src/erizo/Transport.h
+++ b/erizo/src/erizo/Transport.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdio>
 #include "NiceConnection.h"
+#include "./logger.h"
 
 /**
  * States of Transport
@@ -24,7 +25,7 @@ class TransportListener {
   virtual void onCandidate(const CandidateInfo& cand, Transport *transport) = 0;
 };
 
-class Transport : public NiceConnectionListener {
+class Transport : public NiceConnectionListener, public LogContext {
  public:
   boost::shared_ptr<NiceConnection> nice_;
   MediaType mediaType;
@@ -67,6 +68,10 @@ class Transport : public NiceConnectionListener {
     return nice_->setRemoteCandidates(candidates, isBundle);
   }
   bool rtcp_mux_;
+
+  inline const char* toLog() {
+    return ("id: " + connection_id_ + ", " + printLogContext()).c_str();
+  }
 
  private:
   TransportListener *transpListener_;

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -6,6 +6,8 @@
 
 #include <string>
 #include <queue>
+#include <map>
+#include <vector>
 
 #include "./logger.h"
 #include "./SdpInfo.h"
@@ -52,7 +54,7 @@ class WebRtcConnectionStatsListener {
  * it comprises all the necessary Transport components.
  */
 class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSink, public FeedbackSource,
-                        public TransportListener, public webrtc::RtpData,
+                        public TransportListener, public webrtc::RtpData, public LogContext,
                         public std::enable_shared_from_this<WebRtcConnection> {
   DECLARE_LOGGER();
 
@@ -145,6 +147,8 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
 
   void setSlideShowMode(bool state);
 
+  void setMetadata(std::map<std::string, std::string> metadata);
+
   // webrtc::RtpHeader overrides.
   int32_t OnReceivedPayloadData(const uint8_t* payloadData, const uint16_t payloadSize,
                                 const webrtc::WebRtcRTPHeader* rtpHeader) override;
@@ -198,7 +202,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   int deliverFeedback_(char* buf, int len) override;
 
   inline const char* toLog() {
-    return (std::string("id: ") + connection_id_).c_str();
+    return ("id: " + connection_id_ + ", " + printLogContext()).c_str();
   }
 
   // Utils

--- a/erizo/src/erizo/logger.h
+++ b/erizo/src/erizo/logger.h
@@ -39,10 +39,9 @@ class LogContext {
   void setLogContext(std::map<std::string, std::string> context) {
     context_ = context;
     context_log_ = "";
-    std::for_each(context.begin(), context.end(),
-                  [this](std::pair<std::string, std::string> item) {
+    for (const std::pair<std::string, std::string> &item : context) {
       context_log_ += item.first + ": " + item.second + ", ";
-    });
+    }
   }
 
   void copyLogContextFrom(LogContext *log_context) {

--- a/erizo/src/erizo/logger.h
+++ b/erizo/src/erizo/logger.h
@@ -25,6 +25,39 @@
 #include <log4cxx/logger.h>
 #include <log4cxx/helpers/exception.h>
 
+#include <map>
+#include <string>
+#include <utility>
+
+class LogContext {
+ public:
+  LogContext() : context_log_{""} {
+  }
+
+  virtual ~LogContext() {}
+
+  void setLogContext(std::map<std::string, std::string> context) {
+    context_ = context;
+    context_log_ = "";
+    std::for_each(context.begin(), context.end(),
+                  [this](std::pair<std::string, std::string> item) {
+      context_log_ += item.first + ": " + item.second + ", ";
+    });
+  }
+
+  void copyLogContextFrom(LogContext *log_context) {
+    setLogContext(log_context->context_);
+  }
+
+  std::string printLogContext() {
+    return context_log_;
+  }
+
+ private:
+  std::string context_log_;
+  std::map<std::string, std::string> context_;
+};
+
 #define DECLARE_LOGGER() \
 static log4cxx::LoggerPtr logger;
 

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -3,6 +3,7 @@
 #endif
 
 #include "WebRtcConnection.h"
+
 #include "lib/json.hpp"
 
 using v8::HandleScope;
@@ -46,6 +47,7 @@ NAN_MODULE_INIT(WebRtcConnection::Init) {
   Nan::SetPrototypeMethod(tpl, "setFeedbackReports", setFeedbackReports);
   Nan::SetPrototypeMethod(tpl, "createOffer", createOffer);
   Nan::SetPrototypeMethod(tpl, "setSlideShowMode", setSlideShowMode);
+  Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
 
   constructor.Reset(tpl->GetFunction());
   Nan::Set(target, Nan::New("WebRtcConnection").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -205,6 +207,23 @@ NAN_METHOD(WebRtcConnection::setSlideShowMode) {
   bool v = info[0]->BooleanValue();
   me->setSlideShowMode(v);
   info.GetReturnValue().Set(Nan::New(v));
+}
+
+NAN_METHOD(WebRtcConnection::setMetadata) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  erizo::WebRtcConnection *me = obj->me;
+
+  v8::String::Utf8Value json_param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string metadata_string = std::string(*json_param);
+  json metadata_json = json::parse(metadata_string);
+  std::map<std::string, std::string> metadata;
+  for (json::iterator item = metadata_json.begin(); item != metadata_json.end(); ++item) {
+    metadata[item.key()] = item.value();
+  }
+
+  me->setMetadata(metadata);
+
+  info.GetReturnValue().Set(Nan::New(true));
 }
 
 NAN_METHOD(WebRtcConnection::setRemoteSdp) {

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -109,6 +109,11 @@ class WebRtcConnection : public MediaSink, erizo::WebRtcConnectionEventListener,
      * Returns: True if the callback was set successfully
      */
     static NAN_METHOD(getStats);
+    /*
+     * Sets Metadata that will be logged in every message
+     * Param: An object with metadata {key1:value1, key2: value2}
+     */
+    static NAN_METHOD(setMetadata);
 
     static Nan::Persistent<v8::Function> constructor;
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -459,6 +459,7 @@ Erizo.Room = function (spec) {
                                               audio: stream.hasAudio(),
                                               video: stream.hasVideo(),
                                               attributes: stream.getAttributes(),
+                                              metadata: options.metadata,
                                               createOffer: options.createOffer},
                                   arg, function (id, error) {
 
@@ -495,6 +496,7 @@ Erizo.Room = function (spec) {
                                               audio: stream.hasAudio(),
                                               video: stream.hasVideo(),
                                               screen: stream.hasScreen(),
+                                              metadata: options.metadata,
                                               attributes: stream.getAttributes()},
                                   undefined, function (id, error) {
                         if (id === null) {
@@ -530,6 +532,7 @@ Erizo.Room = function (spec) {
                                               minVideoBW: options.minVideoBW,
                                               attributes: stream.getAttributes(),
                                               createOffer: options.createOffer,
+                                              metadata: options.metadata,
                                               scheme: options.scheme},
                                   undefined, function (id, error) {
 
@@ -598,6 +601,7 @@ Erizo.Room = function (spec) {
                                           audio: false,
                                           video: false,
                                           screen: false,
+                                          metadata: options.metadata,
                                           attributes: stream.getAttributes()},
                               undefined,
                               function (id, error) {
@@ -720,7 +724,8 @@ Erizo.Room = function (spec) {
                 // 1- Subscribe to Stream
 
                 if (that.p2p) {
-                    sendSDPSocket('subscribe', {streamId: stream.getID()});
+                    sendSDPSocket('subscribe', {streamId: stream.getID(),
+                                                metadata: options.metadata});
                     if(callback) callback(true);
                 } else {
                     L.Logger.info('Checking subscribe options for', stream.getID());
@@ -731,6 +736,7 @@ Erizo.Room = function (spec) {
                                                 data: options.data,
                                                 browser: Erizo.getBrowser(),
                                                 createOffer: options.createOffer,
+                                                metadata: options.metadata,
                                                 slideShowMode: options.slideShowMode},
                                   undefined, function (result, error) {
                             if (result === null) {
@@ -787,7 +793,9 @@ Erizo.Room = function (spec) {
                 }
             } else if (stream.hasData() && options.data !== false) {
                 sendSDPSocket('subscribe',
-                              {streamId: stream.getID(), data: options.data},
+                              {streamId: stream.getID(),
+                               data: options.data,
+                               metadata: options.metadata},
                               undefined, function (result, error) {
                     if (result === null) {
                         L.Logger.error('Error subscribing to stream ', error);

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -199,7 +199,7 @@ exports.RoomController = function (spec) {
                                      'retries: ' + retries);
                             publishers[publisherId] = undefined;
                             retries++;
-                            that.addPublisher(publisherId, options,callback, retries);
+                            that.addPublisher(publisherId, options, callback, retries);
                             return;
                         }
                         log.warn('message: addPublisher ErizoJS timeout no retry, ' +

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -93,7 +93,7 @@ window.onload = function () {
         for (var index in streams) {
           var stream = streams[index];
           if (localStream.getID() !== stream.getID()) {
-            room.subscribe(stream, {slideShowMode: slideShowMode});
+            room.subscribe(stream, {slideShowMode: slideShowMode, metadata: {type: 'subscriber'}});
             stream.addEventListener('bandwidth-alert', cb);
           }
         }
@@ -101,7 +101,7 @@ window.onload = function () {
 
       room.addEventListener('room-connected', function (roomEvent) {
 
-        room.publish(localStream, {maxVideoBW: 300});
+        room.publish(localStream, {maxVideoBW: 300, metadata: {type: 'publisher'}});
         subscribeToStreams(roomEvent.streams);
       });
 


### PR DESCRIPTION
With this change both publish() and subscribe() methods in clients will accept a new field in options called metadata. 

Metadata is an Object with keys and values, both should be strings. Below you can find an example:
```
{metadata: {type: 'publisher', external_id: 'id1'}}
```

All fields inside metadata will be printed in logs in Erizo in this PR. And we will add them to ErizoController logs too.
