### PR TITLE
Removed maxptime as it no longer makes sense here

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -273,7 +273,6 @@ namespace erizo {
         audioSsrc = 44444;
       }
 
-      sdp << "a=maxptime:60" << endl;
       sdp << "a=ssrc:" << audioSsrc << " cname:o/i14u9pJrxRKAsu" << endl <<
         "a=ssrc:"<< audioSsrc << " msid:"<< msidtemp << " a0"<< endl <<
         "a=ssrc:"<< audioSsrc << " mslabel:"<< msidtemp << endl <<


### PR DESCRIPTION
We were including a=maxptime:60 it is legacy code