### PR TITLE
allwo to set mediaSource(window|screen) for screen sharing in Firefox

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -73,16 +73,10 @@ Erizo.GetUserMedia = function (config, callback, error) {
         switch (Erizo.getBrowser()) {
             case 'mozilla':
                 L.Logger.debug('Screen sharing in Firefox');
-                var screenCfg = {};
-                if (config.video.mandatory !== undefined) {
-                    screenCfg.video = config.video;
-                    screenCfg.video.mediaSource = 'window' || 'screen';
-                } else {
-                    screenCfg = {
-                        audio: config.audio,
-                        video: {mediaSource: 'window' || 'screen'}
-                    };
-                }
+                var screenCfg = {
+                    audio: config.audio,
+                    video: config.video
+                };
                 if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
                     promise = navigator.mediaDevices.getUserMedia(screenCfg).then(callback);
                     // Google compressor complains about a func called catch

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -90,15 +90,17 @@ Erizo.Stream = function (spec) {
       try {
         if ((spec.audio || spec.video || spec.screen) && spec.url === undefined) {
           L.Logger.info('Requested access to local media');
-          var videoOpt = spec.video;
-          if ((videoOpt === true || spec.screen === true) &&
-              that.videoSize !== undefined) {
-            videoOpt = {mandatory: {minWidth: that.videoSize[0],
-                                    minHeight: that.videoSize[1],
-                                    maxWidth: that.videoSize[2],
-                                    maxHeight: that.videoSize[3]}};
-          } else if (spec.screen === true && videoOpt === undefined) {
-            videoOpt = true;
+          var videoOpt = {};
+          if ((spec.video === true || spec.screen === true)) {
+            videoOpt.mediaSource = spec.mediaSource || 'window';
+            if (that.videoSize !== undefined) {
+              videoOpt.mandatory = {
+                minWidth: that.videoSize[0],
+                minHeight: that.videoSize[1],
+                maxWidth: that.videoSize[2],
+                maxHeight: that.videoSize[3]
+              };
+            }
           }
           var opt = {video: videoOpt,
                      audio: spec.audio,


### PR DESCRIPTION
**Usage:**
`Erizo.Stream({screen: true, mediaSource: 'screen'});`

It has no effect on Chrome.