### PR TITLE
Add a ThreadPool for WebRtcConnections

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -21,8 +21,8 @@
 namespace erizo {
 DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
 
-WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id, const IceConfig& iceConfig,
-    std::vector<RtpMap> rtp_mappings, WebRtcConnectionEventListener* listener) :
+WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id,
+    const IceConfig& iceConfig, std::vector<RtpMap> rtp_mappings, WebRtcConnectionEventListener* listener) :
     connection_id_{connection_id}, remoteSdp_{SdpInfo(rtp_mappings)}, localSdp_{SdpInfo(rtp_mappings)},
         audioEnabled_{false}, videoEnabled_{false}, bundle_{false}, connEventListener_{listener},
         iceConfig_{iceConfig}, rtp_mappings_{rtp_mappings}, fec_receiver_{this}, pipeline_{Pipeline::create()},

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -21,12 +21,12 @@
 namespace erizo {
 DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
 
-WebRtcConnection::WebRtcConnection(const std::string& connection_id, const IceConfig& iceConfig,
+WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id, const IceConfig& iceConfig,
     std::vector<RtpMap> rtp_mappings, WebRtcConnectionEventListener* listener) :
     connection_id_{connection_id}, remoteSdp_{SdpInfo(rtp_mappings)}, localSdp_{SdpInfo(rtp_mappings)},
         audioEnabled_{false}, videoEnabled_{false}, bundle_{false}, connEventListener_{listener},
         iceConfig_{iceConfig}, rtp_mappings_{rtp_mappings}, fec_receiver_{this}, pipeline_{Pipeline::create()},
-        worker_{std::make_shared<Worker>()} {
+        worker_{worker} {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort);
   setVideoSinkSSRC(55543);
@@ -78,11 +78,9 @@ WebRtcConnection::~WebRtcConnection() {
 }
 
 void WebRtcConnection::close() {
-  worker_->close();
 }
 
 bool WebRtcConnection::init() {
-  worker_->start();
   rtcpProcessor_ = boost::shared_ptr<RtcpProcessor>(
                     new RtcpForwarder(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this)));
   if (connEventListener_ != NULL) {

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -64,7 +64,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
    * Constructor.
    * Constructs an empty WebRTCConnection without any configuration.
    */
-  WebRtcConnection(const std::string& connection_id, const IceConfig& iceConfig,
+  WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id, const IceConfig& iceConfig,
       const std::vector<RtpMap> rtp_mappings, WebRtcConnectionEventListener* listener);
   /**
    * Destructor.

--- a/erizo/src/erizo/thread/ThreadPool.cpp
+++ b/erizo/src/erizo/thread/ThreadPool.cpp
@@ -1,0 +1,38 @@
+#include "thread/ThreadPool.h"
+
+#include <memory>
+
+using erizo::ThreadPool;
+using erizo::Worker;
+
+ThreadPool::ThreadPool(unsigned int num_workers) : workers_{} {
+  for (unsigned int index = 0; index < num_workers; index++) {
+    workers_.push_back(std::make_shared<Worker>());
+  }
+}
+
+ThreadPool::~ThreadPool() {
+  close();
+}
+
+std::shared_ptr<Worker> ThreadPool::getLessUsedWorker() {
+  std::shared_ptr<Worker> chosen_worker = workers_.front();
+  for (auto worker : workers_) {
+    if (chosen_worker.use_count() > worker.use_count()) {
+      chosen_worker = worker;
+    }
+  }
+  return chosen_worker;
+}
+
+void ThreadPool::start() {
+  for (auto worker : workers_) {
+    worker->start();
+  }
+}
+
+void ThreadPool::close() {
+  for (auto worker : workers_) {
+    worker->close();
+  }
+}

--- a/erizo/src/erizo/thread/ThreadPool.h
+++ b/erizo/src/erizo/thread/ThreadPool.h
@@ -10,37 +10,12 @@ namespace erizo {
 
 class ThreadPool {
  public:
-  explicit ThreadPool(unsigned int num_workers) : workers_{} {
-    for (unsigned int index = 0; index < num_workers; index++) {
-      workers_.push_back(std::make_shared<Worker>());
-    }
-  }
+  explicit ThreadPool(unsigned int num_workers);
+  ~ThreadPool();
 
-  ~ThreadPool() {
-    close();
-  }
-
-  std::shared_ptr<Worker> getLessUsedWorker() {
-    std::shared_ptr<Worker> choosed_worker = workers_.front();
-    for (auto worker : workers_) {
-      if (choosed_worker.use_count() > worker.use_count()) {
-        choosed_worker = worker;
-      }
-    }
-    return choosed_worker;
-  }
-
-  void start() {
-    for (auto worker : workers_) {
-      worker->start();
-    }
-  }
-
-  void close() {
-    for (auto worker : workers_) {
-      worker->close();
-    }
-  }
+  std::shared_ptr<Worker> getLessUsedWorker();
+  void start();
+  void close();
 
  private:
   std::vector<std::shared_ptr<Worker>> workers_;

--- a/erizo/src/erizo/thread/ThreadPool.h
+++ b/erizo/src/erizo/thread/ThreadPool.h
@@ -1,0 +1,50 @@
+#ifndef ERIZO_SRC_ERIZO_THREAD_THREADPOOL_H_
+#define ERIZO_SRC_ERIZO_THREAD_THREADPOOL_H_
+
+#include <memory>
+#include <vector>
+
+#include "thread/Worker.h"
+
+namespace erizo {
+
+class ThreadPool {
+ public:
+  explicit ThreadPool(unsigned int num_workers) : workers_{} {
+    for (unsigned int index = 0; index < num_workers; index++) {
+      workers_.push_back(std::make_shared<Worker>());
+    }
+  }
+
+  ~ThreadPool() {
+    close();
+  }
+
+  std::shared_ptr<Worker> getLessUsedWorker() {
+    std::shared_ptr<Worker> choosed_worker = workers_.front();
+    for (auto worker : workers_) {
+      if (choosed_worker.use_count() > worker.use_count()) {
+        choosed_worker = worker;
+      }
+    }
+    return choosed_worker;
+  }
+
+  void start() {
+    for (auto worker : workers_) {
+      worker->start();
+    }
+  }
+
+  void close() {
+    for (auto worker : workers_) {
+      worker->close();
+    }
+  }
+
+ private:
+  std::vector<std::shared_ptr<Worker>> workers_;
+};
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_THREAD_THREADPOOL_H_

--- a/erizo/src/erizo/thread/Worker.cpp
+++ b/erizo/src/erizo/thread/Worker.cpp
@@ -1,0 +1,32 @@
+#include "thread/Worker.h"
+
+#include <boost/asio.hpp>
+#include <boost/thread.hpp>
+
+#include <memory>
+
+using erizo::Worker;
+
+Worker::Worker() : service_{}, service_worker_{new asio_worker::element_type(service_)}, closed_{false} {
+}
+
+Worker::~Worker() {
+}
+
+void Worker::start() {
+  auto this_ptr = shared_from_this();
+  auto worker = [this_ptr] {
+    if (!this_ptr->closed_) {
+      return this_ptr->service_.run();
+    }
+    return size_t(0);
+  };
+  group_.add_thread(new boost::thread(worker));
+}
+
+void Worker::close() {
+  closed_ = true;
+  service_worker_.reset();
+  group_.join_all();
+  service_.stop();
+}

--- a/erizo/src/erizo/thread/Worker.h
+++ b/erizo/src/erizo/thread/Worker.h
@@ -12,34 +12,16 @@ class Worker : public std::enable_shared_from_this<Worker> {
  public:
   typedef std::unique_ptr<boost::asio::io_service::work> asio_worker;
 
-  Worker() : service_{}, service_worker_{new asio_worker::element_type(service_)}, closed_{false} {
-  }
+  Worker();
+  ~Worker();
 
   template<class F>
   void task(F f) {
     service_.post(f);
   }
 
-  void start() {
-    auto this_ptr = shared_from_this();
-    auto worker = [this_ptr] {
-      if (!this_ptr->closed_) {
-        return this_ptr->service_.run();
-      }
-      return size_t(0);
-    };
-    group_.add_thread(new boost::thread(worker));
-  }
-
-  void close() {
-    closed_ = true;
-    service_worker_.reset();
-    group_.join_all();
-    service_.stop();
-  }
-
-  ~Worker() {
-  }
+  void start();
+  void close();
 
  private:
   boost::asio::io_service service_;

--- a/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
@@ -28,11 +28,12 @@ using erizo::WebRtcConnection;
 using erizo::Pipeline;
 using erizo::InboundHandler;
 using erizo::OutboundHandler;
+using erizo::Worker;
 
 class MockWebRtcConnection: public WebRtcConnection {
  public:
   MockWebRtcConnection(const IceConfig &ice_config, const std::vector<RtpMap> rtp_mappings) :
-    WebRtcConnection("", ice_config, rtp_mappings, nullptr) {}
+    WebRtcConnection(std::make_shared<Worker>(), "", ice_config, rtp_mappings, nullptr) {}
 
   virtual ~MockWebRtcConnection() {
   }

--- a/erizoAPI/ThreadPool.cc
+++ b/erizoAPI/ThreadPool.cc
@@ -1,0 +1,60 @@
+#ifndef BUILDING_NODE_EXTENSION
+#define BUILDING_NODE_EXTENSION
+#endif
+
+#include "ThreadPool.h"
+
+using v8::Local;
+using v8::Value;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::HandleScope;
+using v8::Exception;
+
+Nan::Persistent<Function> ThreadPool::constructor;
+
+ThreadPool::ThreadPool() {
+}
+
+ThreadPool::~ThreadPool() {
+}
+
+NAN_MODULE_INIT(ThreadPool::Init) {
+  // Prepare constructor template
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("ThreadPool").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  // Prototype
+  Nan::SetPrototypeMethod(tpl, "close", close);
+  Nan::SetPrototypeMethod(tpl, "start", start);
+
+  constructor.Reset(tpl->GetFunction());
+  Nan::Set(target, Nan::New("ThreadPool").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+}
+
+NAN_METHOD(ThreadPool::New) {
+  if (info.Length() < 1) {
+    ThrowException(Exception::TypeError(v8::String::New("Wrong number of arguments")));
+  }
+
+  unsigned int num_workers = info[0]->IntegerValue();
+
+  ThreadPool* obj = new ThreadPool();
+  obj->me.reset(new erizo::ThreadPool(num_workers));
+
+  obj->Wrap(info.This());
+  info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(ThreadPool::close) {
+  ThreadPool* obj = Nan::ObjectWrap::Unwrap<ThreadPool>(info.Holder());
+
+  obj->me->close();
+}
+
+NAN_METHOD(ThreadPool::start) {
+  ThreadPool* obj = Nan::ObjectWrap::Unwrap<ThreadPool>(info.Holder());
+
+  obj->me->start();
+}

--- a/erizoAPI/ThreadPool.h
+++ b/erizoAPI/ThreadPool.h
@@ -1,0 +1,41 @@
+#ifndef ERIZOAPI_THREADPOOL_H_
+#define ERIZOAPI_THREADPOOL_H_
+
+#include <nan.h>
+#include <thread/ThreadPool.h>
+
+
+/*
+ * Wrapper class of erizo::ThreadPool
+ *
+ * Represents a OneToMany connection.
+ * Receives media from one publisher and retransmits it to every subscriber.
+ */
+class ThreadPool : public Nan::ObjectWrap {
+ public:
+    static NAN_MODULE_INIT(Init);
+    std::unique_ptr<erizo::ThreadPool> me;
+
+ private:
+    ThreadPool();
+    ~ThreadPool();
+
+    /*
+     * Constructor.
+     * Constructs a ThreadPool
+     */
+    static NAN_METHOD(New);
+    /*
+     * Closes the ThreadPool.
+     * The object cannot be used after this call
+     */
+    static NAN_METHOD(close);
+    /*
+     * Starts all workers in the ThreadPool
+     */
+    static NAN_METHOD(start);
+
+    static Nan::Persistent<v8::Function> constructor;
+};
+
+#endif  // ERIZOAPI_THREADPOOL_H_

--- a/erizoAPI/addon.cc
+++ b/erizoAPI/addon.cc
@@ -7,12 +7,14 @@
 #include "OneToManyTranscoder.h"
 #include "ExternalInput.h"
 #include "ExternalOutput.h"
+#include "ThreadPool.h"
 
 NAN_MODULE_INIT(InitAll) {
   WebRtcConnection::Init(target);
   OneToManyProcessor::Init(target);
   ExternalInput::Init(target);
   ExternalOutput::Init(target);
+  ThreadPool::Init(target);
 }
 
 NODE_MODULE(addon, InitAll)

--- a/erizoAPI/binding.gyp
+++ b/erizoAPI/binding.gyp
@@ -2,7 +2,7 @@
   'targets': [
   {
     'target_name': 'addon',
-      'sources': [ 'addon.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc'],
+      'sources': [ 'addon.cc', 'ThreadPool.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc'],
       'include_dirs' : ["<!(node -e \"require('nan')\")", '$(ERIZO_HOME)/src/erizo', '$(ERIZO_HOME)/../build/libdeps/build/include'],
       'libraries': ['-L$(ERIZO_HOME)/build/erizo', '-lerizo'],
       'conditions': [
@@ -19,7 +19,7 @@
           'cflags!' : ['-fno-exceptions'],
           'cflags' : ['-D__STDC_CONSTANT_MACROS'],
           'cflags_cc' : ['-Wall', '-O3', '-g' , '-std=c++11', '-fexceptions'],
-          'cflags_cc!' : ['-fno-exceptions'], 
+          'cflags_cc!' : ['-fno-exceptions'],
           'cflags_cc!' : ['-fno-rtti']
         }],
         ]

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -1,11 +1,13 @@
 /*global require*/
 'use strict';
 var Getopt = require('node-getopt');
+var addon = require('./../../erizoAPI/build/Release/addon');
 var config = require('./../../licode_config');
 var mediaConfig = require('./../../rtp_media_config');
 
 GLOBAL.config = config || {};
 GLOBAL.config.erizo = GLOBAL.config.erizo || {};
+GLOBAL.config.erizo.numWorkers = GLOBAL.config.erizo.numWorkers || 24;
 GLOBAL.config.erizo.stunserver = GLOBAL.config.erizo.stunserver || '';
 GLOBAL.config.erizo.stunport = GLOBAL.config.erizo.stunport || 0;
 GLOBAL.config.erizo.minport = GLOBAL.config.erizo.minport || 0;
@@ -73,7 +75,10 @@ var controller = require('./erizoJSController');
 // Logger
 var log = logger.getLogger('ErizoJS');
 
-var ejsController = controller.ErizoJSController();
+var threadPool = new addon.ThreadPool(10);
+threadPool.start();
+
+var ejsController = controller.ErizoJSController(threadPool);
 
 ejsController.keepAlive = function(callback) {
     callback('callback', true);

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -75,7 +75,7 @@ var controller = require('./erizoJSController');
 // Logger
 var log = logger.getLogger('ErizoJS');
 
-var threadPool = new addon.ThreadPool(10);
+var threadPool = new addon.ThreadPool(GLOBAL.config.erizo.numWorkers);
 threadPool.start();
 
 var ejsController = controller.ErizoJSController(threadPool);

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -7,7 +7,7 @@ var amqper = require('./../common/amqper');
 // Logger
 var log = logger.getLogger('ErizoJSController');
 
-exports.ErizoJSController = function () {
+exports.ErizoJSController = function (threadPool) {
     var that = {},
         // {id: {subsId1: wrtc1, subsId2: wrtc2}}
         subscribers = {},
@@ -147,7 +147,7 @@ exports.ErizoJSController = function () {
         var associatedMetadata = wrtc.metadata || {};
         wrtc.close();
         log.info('message: WebRtcConnection status update, ' +
-            'id: ' + wrtc.wrtcId + ', status: ' + CONN_FINISHED + ', ' + 
+            'id: ' + wrtc.wrtcId + ', status: ' + CONN_FINISHED + ', ' +
                 logger.objectToLog(associatedMetadata));
     };
 
@@ -310,7 +310,7 @@ exports.ErizoJSController = function () {
                      logger.objectToLog(options.metadata));
             var wrtcId = from;
             muxer = new addon.OneToManyProcessor();
-            wrtc = new addon.WebRtcConnection(wrtcId,
+            wrtc = new addon.WebRtcConnection(threadPool, wrtcId,
                                               GLOBAL.config.erizo.stunserver,
                                               GLOBAL.config.erizo.stunport,
                                               GLOBAL.config.erizo.minport,
@@ -341,7 +341,7 @@ exports.ErizoJSController = function () {
                          'code: ' + WARN_CONFLICT + ', streamId: ' + from + ', ' +
                          logger.objectToLog(options.metadata));
 
-                wrtc = new addon.WebRtcConnection(from,
+                wrtc = new addon.WebRtcConnection(threadPool, from,
                                                   GLOBAL.config.erizo.stunserver,
                                                   GLOBAL.config.erizo.stunport,
                                                   GLOBAL.config.erizo.minport,
@@ -390,7 +390,7 @@ exports.ErizoJSController = function () {
         log.info('message: Adding subscriber, id: ' + wrtcId + ', ' +
                  logger.objectToLog(options)+
                   ', ' + logger.objectToLog(options.metadata));
-        var wrtc = new addon.WebRtcConnection(wrtcId,
+        var wrtc = new addon.WebRtcConnection(threadPool, wrtcId,
                                               GLOBAL.config.erizo.stunserver,
                                               GLOBAL.config.erizo.stunport,
                                               GLOBAL.config.erizo.minport,
@@ -498,7 +498,7 @@ exports.ErizoJSController = function () {
             }
         }
     };
-    
+
     /*
      * Enables/Disables slideshow mode for a subscriber
      */

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -157,7 +157,7 @@ describe('Erizo JS Controller', function() {
       controller.addPublisher(kArbitraryId, {}, callback);
 
       expect(erizoApiMock.OneToManyProcessor.callCount).to.equal(1);
-      expect(erizoApiMock.WebRtcConnection.args[0][0]).to.equal(kArbitraryId);
+      expect(erizoApiMock.WebRtcConnection.args[0][1]).to.equal(kArbitraryId);
       expect(erizoApiMock.WebRtcConnection.callCount).to.equal(1);
       expect(mocks.WebRtcConnection.wrtcId).to.equal(kArbitraryId);
       expect(mocks.WebRtcConnection.setAudioReceiver.args[0][0]).to.equal(mocks.OneToManyProcessor);
@@ -174,7 +174,7 @@ describe('Erizo JS Controller', function() {
       controller.addPublisher(kArbitraryId, {}, callback);
 
       expect(erizoApiMock.OneToManyProcessor.callCount).to.equal(1);
-      expect(erizoApiMock.WebRtcConnection.args[0][0]).to.equal(kArbitraryId);
+      expect(erizoApiMock.WebRtcConnection.args[0][1]).to.equal(kArbitraryId);
       expect(erizoApiMock.WebRtcConnection.callCount).to.equal(2);
       expect(mocks.WebRtcConnection.wrtcId).to.equal(kArbitraryId);
       expect(mocks.WebRtcConnection.setAudioReceiver.args[1][0]).to.equal(mocks.OneToManyProcessor);
@@ -305,7 +305,7 @@ describe('Erizo JS Controller', function() {
         controller.addSubscriber(kArbitraryId2, kArbitraryId, {}, subCallback);
 
         expect(erizoApiMock.WebRtcConnection.callCount).to.equal(2);
-        expect(erizoApiMock.WebRtcConnection.args[1][0]).to.equal(kArbitraryId2 +
+        expect(erizoApiMock.WebRtcConnection.args[1][1]).to.equal(kArbitraryId2 +
                                                             '_' + kArbitraryId);
         expect(mocks.WebRtcConnection.wrtcId).to.equal(kArbitraryId2 + '_' + kArbitraryId);
         expect(mocks.OneToManyProcessor.addSubscriber.callCount).to.equal(1);

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -140,6 +140,9 @@ config.erizo = {};
 //Erizo Logs are piped through erizoAgent by default
 //you can control log levels in [licode_path]/erizo_controller/erizoAgent/log4cxx.properties
 
+// Number of workers that will be used to handle WebRtcConnections
+config.erizo.numWorkers = 24;
+
 //STUN server IP address and port to be used by the server.
 //if '' is used, the address is discovered locally
 //Please note this is only needed if your server does not have a public IP

--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -15,6 +15,9 @@ exports.ErizoNativeConnection = function (spec){
     externalInput,
     externalOutput;
 
+    var threadPool = new addon.ThreadPool(1);
+    threadPool.start();
+
     var CONN_INITIAL = 101,
         // CONN_STARTED = 102,
         CONN_GATHERED = 103,
@@ -77,7 +80,7 @@ exports.ErizoNativeConnection = function (spec){
     };
 
 
-    wrtc = new addon.WebRtcConnection('spine',
+    wrtc = new addon.WebRtcConnection(threadPool, 'spine',
                                       GLOBAL.config.erizo.stunserver,
                                       GLOBAL.config.erizo.stunport,
                                       GLOBAL.config.erizo.minport,


### PR DESCRIPTION
This PR sets a ThreadPool that will be used to get Workers and assign them to WebRtcConnections. These workers will be threads processing RTP packets, but they won't do IO tasks.

I've added a new parameter in the configuration called numWorkers, that is the total number of threads that will be used by Erizo to process RTP packets.