### PR TITLE
Removed 'transport-cc' to disable sender side-only bandwidth estimation

### DIFF
--- a/scripts/rtp_media_config_default.js
+++ b/scripts/rtp_media_config_default.js
@@ -13,7 +13,7 @@ mediaConfig.rtpMappings.vp8 = {
         'nack',
         'nack pli',
         'goog-remb',
-        'transport-cc',
+//        'transport-cc',
     ],
 };
 

--- a/scripts/rtp_media_config_default.js
+++ b/scripts/rtp_media_config_default.js
@@ -16,7 +16,7 @@ mediaConfig.rtpMappings.vp8 = {
 //        'transport-cc',
     ],
 };
-
+/*
 mediaConfig.rtpMappings.red = {
     payloadType: 116,
     encodingName: 'red',
@@ -24,7 +24,7 @@ mediaConfig.rtpMappings.red = {
     channels: 1,
     mediaType: 'video',
 };
-/*
+
 mediaConfig.rtpMappings.rtx = {
     payloadType: 96,
     encodingName: 'rtx',


### PR DESCRIPTION
in Chrome

From [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/discuss-webrtc/BqqFMSR6s1E/rlPYFD0NCQAJ)
