### PR TITLE
Fixes a crash in ExternalOutput even when we don't use FEC/RED

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -48,7 +48,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   void close() override {}
 
  private:
-  webrtc::UlpfecReceiverImpl  fec_receiver_;
+  std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
   RtpPacketQueue audioQueue_, videoQueue_;
   bool recording_, inited_;
   boost::mutex mtx_;  // a mutex we use to signal our writer thread that data is waiting.


### PR DESCRIPTION
I've changed the initialization of the FEC Receiver by using the new API and I've tested it locally several times successfully.

@kekkokk can you check if this PR fixes #658 please? I think the real issue arose when I updated webrtc library because I didn't change this code.