### PR TITLE
Fix REMB estimator in Erizo to improve initial ramp up

### DIFF
--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -18,10 +18,9 @@ DEFINE_LOGGER(BandwidthEstimationHandler, "rtp.BandwidthEstimationHandler");
 
 static const uint32_t kTimeOffsetSwitchThreshold = 30;
 static const uint32_t kMinBitRateAllowed = 10;
-static const uint32_t kRembInitialBitrateKbps = 300;
 const int kRembTimeOutThresholdMs = 2000;
-const int kRembSendIntervallMs = 1000;
-const uint32_t BandwidthEstimationHandler::kRembMinimumBitrateKbps = 20;
+const int kRembSendIntervallMs = 200;
+const uint32_t BandwidthEstimationHandler::kRembMinimumBitrate = 20000;
 
 // % threshold for if we should send a new REMB asap.
 const unsigned int kSendThresholdPercent = 97;
@@ -47,48 +46,18 @@ BandwidthEstimationHandler::BandwidthEstimationHandler(WebRtcConnection *connect
   rbe_{picker_->pickEstimator(false, clock_, this)},
   using_absolute_send_time_{false}, packets_since_absolute_send_time_{0},
   min_bitrate_bps_{kMinBitRateAllowed}, temp_ctx_{nullptr},
-  bitrate_{0}, last_send_bitrate_{0},
-  bitrate_update_time_ms_{0}, last_remb_time_{0},
+  bitrate_{0}, last_send_bitrate_{0}, last_remb_time_{0},
   running_{false} {
 }
 
 void BandwidthEstimationHandler::process() {
   rbe_->Process();
-  sendREMBPacketMaybe();
   std::weak_ptr<BandwidthEstimationHandler> weak_ptr = shared_from_this();
   worker_->scheduleFromNow([weak_ptr]() {
     if (auto this_ptr = weak_ptr.lock()) {
       this_ptr->process();
     }
   }, std::chrono::milliseconds(rbe_->TimeUntilNextProcess()));
-}
-
-void BandwidthEstimationHandler::sendREMBPacketMaybe() {
-  uint64_t now = ClockUtils::timePointToMs(clock::now());
-  if (now - last_remb_time_ < kRembSendIntervallMs) {
-    return;
-  }
-
-  last_remb_time_ = now;
-
-  if (now - bitrate_update_time_ms_ > kRembTimeOutThresholdMs) {
-    bitrate_ = 0;
-    bitrate_update_time_ms_ = -1;
-    return;
-  }
-
-  if (last_send_bitrate_ == 0) {
-    last_send_bitrate_ = kRembInitialBitrateKbps * 1000;
-  } else {
-    last_send_bitrate_ = bitrate_;
-  }
-
-
-  if (last_send_bitrate_ < kRembMinimumBitrateKbps * 1000) {
-    last_send_bitrate_ = kRembMinimumBitrateKbps * 1000;
-  }
-
-  sendREMBPacket();
 }
 
 void BandwidthEstimationHandler::updateExtensionMaps(std::array<RTPExtensions, 10> video_map,
@@ -210,7 +179,7 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   remb_packet_.setSSRC(connection_->getVideoSinkSSRC());
   remb_packet_.setSourceSSRC(connection_->getVideoSourceSSRC());
   remb_packet_.setLength(5);
-  remb_packet_.setREMBBitRate(last_send_bitrate_);
+  remb_packet_.setREMBBitRate(bitrate_);
   remb_packet_.setREMBNumSSRC(1);
   remb_packet_.setREMBFeedSSRC(connection_->getVideoSourceSSRC());
   int remb_length = (remb_packet_.getLength() + 1) * 4;
@@ -225,14 +194,26 @@ void BandwidthEstimationHandler::OnReceiveBitrateChanged(const std::vector<uint3
                                      uint32_t bitrate) {
   if (last_send_bitrate_ > 0) {
     unsigned int new_remb_bitrate = last_send_bitrate_ - bitrate_ + bitrate;
-
     if (new_remb_bitrate < kSendThresholdPercent * last_send_bitrate_ / 100) {
       // The new bitrate estimate is less than kSendThresholdPercent % of the
       // last report. Send a REMB asap.
       last_remb_time_ = ClockUtils::timePointToMs(clock::now()) - kRembSendIntervallMs;
     }
   }
+
+  if (bitrate < kRembMinimumBitrate) {
+    bitrate = kRembMinimumBitrate;
+  }
+
   bitrate_ = bitrate;
-  bitrate_update_time_ms_ = ClockUtils::timePointToMs(clock::now());
+
+  uint64_t now = ClockUtils::timePointToMs(clock::now());
+
+  if (now - last_remb_time_ < kRembSendIntervallMs) {
+    return;
+  }
+  last_remb_time_ = now;
+  last_send_bitrate_ = bitrate_;
+  sendREMBPacket();
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -35,7 +35,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   DECLARE_LOGGER();
 
  public:
-  static const uint32_t kRembMinimumBitrateKbps;
+  static const uint32_t kRembMinimumBitrate;
 
   explicit BandwidthEstimationHandler(WebRtcConnection *connection, std::shared_ptr<Worker> worker,
     std::shared_ptr<RemoteBitrateEstimatorPicker> picker = std::make_shared<RemoteBitrateEstimatorPicker>());
@@ -51,7 +51,6 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
  private:
   void process();
   void sendREMBPacket();
-  void sendREMBPacketMaybe();
   bool parsePacket(std::shared_ptr<dataPacket> packet);
   RtpHeaderExtensionMap getHeaderExtensionMap(std::shared_ptr<dataPacket> packet) const;
   void pickEstimatorFromHeader();
@@ -72,7 +71,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   RtpHeaderExtensionMap ext_map_audio_, ext_map_video_;
   Context *temp_ctx_;
   uint32_t bitrate_, last_send_bitrate_;
-  uint64_t bitrate_update_time_ms_, last_remb_time_;
+  uint64_t last_remb_time_;
   bool running_;
 };
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpHeaders.h
+++ b/erizo/src/erizo/rtp/RtpHeaders.h
@@ -449,7 +449,7 @@ class RtcpHeader {
     report.rembPacket.brLength = htonl(line) >> 8;
   }
   inline uint64_t getREMBBitRate() {
-    return getBrMantis() + (getBrExp() << 18);
+    return getBrMantis() << getBrExp();
   }
 
   inline uint32_t getBrExp() {


### PR DESCRIPTION
This PR fixes some issues with slow REMB ramp up and removes some warnings.