### PR TITLE
Fixes when checking users from Cloud Handler to Erizo Controller

### DIFF
--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -83,20 +83,28 @@ var deleteRoomsIfEmpty = function (theRooms, callback) {
         callback(true);
         return;
     }
-    var theRoom = theRooms.pop();
-    N.API.getUsers(theRoom._id, function(userlist) {
+    var theRoomId = theRooms.pop()._id;
+    N.API.getUsers(theRoomId, function(userlist) {
         var users = JSON.parse(userlist);
         if (Object.keys(users).length === 0){
-            N.API.deleteRoom(theRoom._id, function(){
+            N.API.deleteRoom(theRoomId, function(){
                 deleteRoomsIfEmpty(theRooms, callback);
             });
         } else {
             deleteRoomsIfEmpty(theRooms, callback);
         }
-    }, function () {
-        N.API.deleteRoom(theRoom._id, function(){
-            deleteRoomsIfEmpty(theRooms, callback);
-        });
+    }, function (error, status) {
+        console.log('Error getting user list for room ', theRoomId, 'reason: ', error);
+        switch (status) {
+            case 404:
+                deleteRoomsIfEmpty(theRooms, callback);
+                break;
+            case 503:
+                N.API.deleteRoom(theRoomId, function(){
+                    deleteRoomsIfEmpty(theRooms, callback);
+                });
+                break;
+        }
     });
 };
 

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -84,19 +84,19 @@ var deleteRoomsIfEmpty = function (theRooms, callback) {
         return;
     }
     var theRoom = theRooms.pop();
-    N.API.getUsers(theRoom._id, function(userlist){
+    N.API.getUsers(theRoom._id, function(userlist) {
         var users = JSON.parse(userlist);
         if (Object.keys(users).length === 0){
             N.API.deleteRoom(theRoom._id, function(){
-                if (theRooms.length > 0){
-                    deleteRoomsIfEmpty(theRooms, callback);
-                }
+                deleteRoomsIfEmpty(theRooms, callback);
             });
         } else {
-            if (theRooms.length > 0){
-                deleteRoomsIfEmpty(theRooms, callback);
-            }
+            deleteRoomsIfEmpty(theRooms, callback);
         }
+    }, function () {
+        N.API.deleteRoom(theRoom._id, function(){
+            deleteRoomsIfEmpty(theRooms, callback);
+        });
     });
 };
 

--- a/nuve/nuveAPI/cloudHandler.js
+++ b/nuve/nuveAPI/cloudHandler.js
@@ -62,7 +62,6 @@ var getEcQueue = function (callback) {
             log.warn('Erizo Controller in ', erizoControllers[n].ip,
                      'has reached the limit number of rooms');
         }
-        console.log('QUEUE', ecQueue);
         callback(ecQueue);
     });
 };
@@ -252,9 +251,6 @@ exports.getUsersInRoom = function (roomId, callback) {
         }
         var rpcID = 'erizoController_' + room.erizoControllerId;
         rpc.callRpc(rpcID, 'getUsersInRoom', [roomId], {'callback': function (users) {
-            if (users === 'timeout') {
-                users = '?';
-            }
             callback(users);
         }});
 

--- a/nuve/nuveAPI/resource/roomResource.js
+++ b/nuve/nuveAPI/resource/roomResource.js
@@ -24,10 +24,10 @@ var doInit = function (req, callback) {
 exports.represent = function (req, res) {
     doInit(req, function (currentRoom) {
         if (req.service === undefined) {
-            res.send('Client unathorized', 401);
+            res.status(401).send('Client unathorized');
         } else if (currentRoom === undefined) {
             log.info('message: representRoom - room does not exits, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
         } else {
             log.info('message: representRoom success, roomId: ' + currentRoom._id +
                 ', serviceId: ' + req.service._id);
@@ -42,13 +42,13 @@ exports.represent = function (req, res) {
 exports.updateRoom = function (req, res) {
     doInit(req, function (currentRoom) {
         if (req.service === undefined) {
-            res.send('Client unathorized', 401);
+            res.status(401).send('Client unathorized');
         } else if (currentRoom === undefined) {
             log.info('message: updateRoom - room does not exist + roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
         } else if (req.body.name === undefined) {
             log.info('message: updateRoom - Invalid room');
-            res.send('Invalid room', 400);
+            res.status(400).send('Invalid room');
         } else {
             var id = '',
                 array = req.service.rooms,
@@ -94,10 +94,10 @@ exports.updateRoom = function (req, res) {
 exports.patchRoom = function (req, res) {
     doInit(req, function (currentRoom) {
         if (req.service === undefined) {
-            res.send('Client unathorized', 401);
+            res.status(401).send('Client unathorized');
         } else if (currentRoom === undefined) {
             log.info('message: pachRoom - room does not exist, roomId : ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
         } else {
             var id = '',
                 array = req.service.rooms,
@@ -145,10 +145,10 @@ exports.patchRoom = function (req, res) {
 exports.deleteRoom = function (req, res) {
     doInit(req, function (currentRoom) {
         if (req.service === undefined) {
-            res.send('Client unathorized', 401);
+            res.status(401).send('Client unathorized');
         } else if (currentRoom === undefined) {
             log.info('message: deleteRoom - room does not exist, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
         } else {
             var id = '',
                 array = req.service.rooms,

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -17,12 +17,12 @@ exports.createRoom = function (req, res) {
     var currentService = req.service;
 
     if (currentService === undefined) {
-        res.send('Service not found', 404);
+        res.status(404).send('Service not found');
         return;
     }
     if (req.body.name === undefined) {
         log.info('message: createRoom - invalid room name');
-        res.send('Invalid room', 400);
+        res.status(400).send('Invalid room');
         return;
     }
 
@@ -67,7 +67,7 @@ exports.createRoom = function (req, res) {
 exports.represent = function (req, res) {
     var currentService = req.service;
     if (currentService === undefined) {
-        res.send('Service not found', 404);
+        res.status(404).send('Service not found');
         return;
     }
     log.info('message: representRooms, serviceId: ' + currentService._id);

--- a/nuve/nuveAPI/resource/serviceResource.js
+++ b/nuve/nuveAPI/resource/serviceResource.js
@@ -32,11 +32,11 @@ exports.represent = function (req, res) {
         if (serv === 'error') {
             log.info('message: represent service - not authorized, serviceId: ' +
                 req.params.service);
-            res.send('Service not authorized for this action', 401);
+            res.status(401).send('Service not authorized for this action');
             return;
         }
         if (serv === undefined) {
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         }
         log.info('Representing service ', serv._id);
@@ -51,11 +51,11 @@ exports.deleteService = function (req, res) {
     doInit(req, function (serv) {
         if (serv === 'error') {
             log.info('message: deleteService - not authorized, serviceId: ' + req.params.service);
-            res.send('Service not authorized for this action', 401);
+            res.status(401).send('Service not authorized for this action');
             return;
         }
         if (serv === undefined) {
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         }
         var id = '';

--- a/nuve/nuveAPI/resource/servicesResource.js
+++ b/nuve/nuveAPI/resource/servicesResource.js
@@ -23,7 +23,7 @@ var doInit = function (req) {
 exports.create = function (req, res) {
     if (!doInit(req)) {
         log.info('message: createService - unauthorized, serviceId: ' + req.service._id);
-        res.send('Service not authorized for this action', 401);
+        res.status(401).send('Service not authorized for this action');
         return;
     }
 
@@ -39,7 +39,7 @@ exports.create = function (req, res) {
 exports.represent = function (req, res) {
     if (!doInit(req)) {
         log.info('message: representService - not authorised, serviceId: ' + req.service._id);
-        res.send('Service not authorized for this action', 401);
+        res.status(401).send('Service not authorized for this action');
         return;
     }
 

--- a/nuve/nuveAPI/resource/tokensResource.js
+++ b/nuve/nuveAPI/resource/tokensResource.js
@@ -143,11 +143,11 @@ exports.create = function (req, res) {
     doInit(req, function (currentService, currentRoom) {
         if (currentService === undefined) {
             log.warn('message: createToken - service not found');
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         } else if (currentRoom === undefined) {
             log.warn('message: createToken - room not found, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
             return;
         }
 

--- a/nuve/nuveAPI/resource/userResource.js
+++ b/nuve/nuveAPI/resource/userResource.js
@@ -28,11 +28,11 @@ exports.getUser = function (req, res) {
     doInit(req, function (currentService, currentRoom) {
 
         if (currentService === undefined) {
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         } else if (currentRoom === undefined) {
             log.info('message: getUser - room not found, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
             return;
         }
 
@@ -41,7 +41,7 @@ exports.getUser = function (req, res) {
 
         cloudHandler.getUsersInRoom(currentRoom._id, function (users) {
             if (users === 'error') {
-                res.send('CloudHandler does not respond', 401);
+                res.status(401).send('CloudHandler does not respond');
                 return;
             }
             for (var index in users){
@@ -54,7 +54,7 @@ exports.getUser = function (req, res) {
 
             }
             log.error('message: getUser user not found, userId: ' + req.params.user);
-            res.send('User does not exist', 404);
+            res.status(404).send('User does not exist');
             return;
 
 
@@ -71,11 +71,11 @@ exports.deleteUser = function (req, res) {
     doInit(req, function (currentService, currentRoom) {
 
         if (currentService === undefined) {
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         } else if (currentRoom === undefined) {
             log.info('message: deleteUser - room not found, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
             return;
         }
 
@@ -83,7 +83,7 @@ exports.deleteUser = function (req, res) {
 
         cloudHandler.deleteUser (user, currentRoom._id, function(result){
             if(result === 'User does not exist'){
-                res.send(result, 404);
+                res.status(404).send(result);
             }
             else {
                 res.send(result);

--- a/nuve/nuveAPI/resource/usersResource.js
+++ b/nuve/nuveAPI/resource/usersResource.js
@@ -27,11 +27,11 @@ exports.getList = function (req, res) {
     doInit(req, function (currentService, currentRoom) {
 
         if (currentService === undefined) {
-            res.send('Service not found', 404);
+            res.status(404).send('Service not found');
             return;
         } else if (currentRoom === undefined) {
             log.info('message: getUserList - room not found, roomId: ' + req.params.room);
-            res.send('Room does not exist', 404);
+            res.status(404).send('Room does not exist');
             return;
         }
 
@@ -39,7 +39,7 @@ exports.getList = function (req, res) {
                  ', serviceId: ' + currentService._id);
         cloudHandler.getUsersInRoom(currentRoom._id, function (users) {
             if (users === 'timeout') {
-                res.send('Erizo Controller managing this room does not respond', 503);
+                res.status(503).send('Erizo Controller managing this room does not respond');
                 return;
             }
             res.send(users);

--- a/nuve/nuveAPI/resource/usersResource.js
+++ b/nuve/nuveAPI/resource/usersResource.js
@@ -38,8 +38,8 @@ exports.getList = function (req, res) {
         log.info('message: getUsersList success, roomId: ' + currentRoom._id +
                  ', serviceId: ' + currentService._id);
         cloudHandler.getUsersInRoom(currentRoom._id, function (users) {
-            if (users === 'error') {
-                res.send('CloudHandler does not respond', 401);
+            if (users === 'timeout') {
+                res.send('Erizo Controller managing this room does not respond', 503);
                 return;
             }
             res.send(users);

--- a/nuve/nuveAPI/test/resource/usersResource.js
+++ b/nuve/nuveAPI/test/resource/usersResource.js
@@ -71,10 +71,10 @@ describe('Users Resource', function() {
     it('should fail if CloudHandler does not respond', function(done) {
       serviceRegistryMock.getRoomForService.callsArgWith(2, kArbitraryRoom);
       setServiceStub.returns(kArbitraryService);
-      cloudHandlerMock.getUsersInRoom.callsArgWith(1, 'error');
+      cloudHandlerMock.getUsersInRoom.callsArgWith(1, 'timeout');
       request(app)
         .get('/rooms/1/users')
-        .expect(401, 'CloudHandler does not respond')
+        .expect(503, 'Erizo Controller managing this room does not respond')
         .end(function(err) {
           if (err) throw err;
           done();

--- a/nuve/nuveClient/src/N.API.js
+++ b/nuve/nuveClient/src/N.API.js
@@ -151,25 +151,9 @@ N.API = (function (N) {
                     case 205:
                         callback(req.responseText);
                         break;
-                    case 400:
-                        if (callbackError !== undefined) 
-                            callbackError('400 Bad Request', req.responseText);
-                        break;
-                    case 401:
-                        if (callbackError !== undefined) 
-                            callbackError('401 Unauthorized', req.responseText);
-                        break;
-                    case 403:
-                        if (callbackError !== undefined) 
-                            callbackError('403 Forbidden', req.responseText);
-                        break;
-                    case 503:
-                        if (callbackError !== undefined) 
-                            callbackError('503 Service Unavailable', req.responseText);
-                        break;
                     default:
                         if (callbackError !== undefined) {
-                          callbackError(req.status + ' Error' + req.responseText);
+                          callbackError(req.status + ' Error' + req.responseText, req.status);
                         }
                 }
             }

--- a/nuve/nuveClient/src/N.API.js
+++ b/nuve/nuveClient/src/N.API.js
@@ -152,13 +152,20 @@ N.API = (function (N) {
                         callback(req.responseText);
                         break;
                     case 400:
-                        if (callbackError !== undefined) callbackError('400 Bad Request');
+                        if (callbackError !== undefined) 
+                            callbackError('400 Bad Request', req.responseText);
                         break;
                     case 401:
-                        if (callbackError !== undefined) callbackError('401 Unauthorized');
+                        if (callbackError !== undefined) 
+                            callbackError('401 Unauthorized', req.responseText);
                         break;
                     case 403:
-                        if (callbackError !== undefined) callbackError('403 Forbidden');
+                        if (callbackError !== undefined) 
+                            callbackError('403 Forbidden', req.responseText);
+                        break;
+                    case 503:
+                        if (callbackError !== undefined) 
+                            callbackError('503 Service Unavailable', req.responseText);
                         break;
                     default:
                         if (callbackError !== undefined) {


### PR DESCRIPTION
When Cloud Handler receives a timeout when checking users in a room, the response is now correctly handled in Nuve Client.

This fixes a break in basic example when removing old rooms.

I've also updated status responses in nuve to new express notation.