### PR TITLE
Enable client API to mute audio on publishers

### DIFF
--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
@@ -1,10 +1,10 @@
 #ifndef ERIZO_SRC_ERIZO_RTP_RTPAUDIOMUTEHANDLER_H_
 #define ERIZO_SRC_ERIZO_RTP_RTPAUDIOMUTEHANDLER_H_
 
-#include <boost/thread/mutex.hpp>
-
 #include "./logger.h"
 #include "pipeline/Handler.h"
+
+#include <mutex>  // NOLINT
 
 namespace erizo {
 
@@ -26,7 +26,7 @@ class RtpAudioMuteHandler: public Handler {
   uint16_t seq_num_offset_, last_sent_seq_num_;
 
   bool mute_is_active_;
-  boost::mutex control_mutex_;
+  std::mutex control_mutex_;
 
   WebRtcConnection* connection_;
 

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -286,11 +286,6 @@ Erizo.Stream = function (spec) {
             callback ('error');
             return;
         }
-        if (that.local) {
-            L.Logger.warning('muteAudio can only be used in remote streams');
-            callback('Error');
-            return;
-        }
         var config = {muteStream : {audio : isMuted}};
         that.checkOptions(config, true);
         that.pc.updateSpec(config, callback);

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -3,19 +3,17 @@
 var addon = require('./../../erizoAPI/build/Release/addon');
 var logger = require('./../common/logger').logger;
 var amqper = require('./../common/amqper');
+var Source = require('./models/Publisher').Source;
+var Publisher = require('./models/Publisher').Publisher;
+var ExternalInput = require('./models/Publisher').ExternalInput;
 
 // Logger
 var log = logger.getLogger('ErizoJSController');
 
 exports.ErizoJSController = function (threadPool) {
     var that = {},
-        // {id: {subsId1: wrtc1, subsId2: wrtc2}}
-        subscribers = {},
-        // {id: {muxer: OneToManyProcessor, wrtc: WebRtcConnection}
+        // {id1: Publisher, id2: Publisher}
         publishers = {},
-
-        // {id: ExternalOutput}
-        externalOutputs = {},
 
         SLIDESHOW_TIME = 1000,
         PLIS_TO_RECOVER = 3,
@@ -190,58 +188,27 @@ exports.ErizoJSController = function (threadPool) {
     };
 
     that.addExternalInput = function (from, url, callback) {
-
         if (publishers[from] === undefined) {
-
-            var eiId = from + '_' + url;
-
-            log.info('message: Adding ExternalInput, id: ' + eiId);
-
-            var muxer = new addon.OneToManyProcessor(),
-                ei = new addon.ExternalInput(url);
-
-            ei.wrtcId = eiId;
-
-            publishers[from] = {muxer: muxer};
-            subscribers[from] = {};
-
-            ei.setAudioReceiver(muxer);
-            ei.setVideoReceiver(muxer);
-            muxer.setExternalPublisher(ei);
-
+            var ei = publishers[from] = new ExternalInput(from, threadPool, url);
             var answer = ei.init();
-
             if (answer >= 0) {
                 callback('callback', 'success');
             } else {
                 callback('callback', answer);
             }
-
         } else {
             log.warn('message: Publisher already set, code: ' + WARN_CONFLICT + ', id: ' + from);
         }
     };
 
     that.addExternalOutput = function (to, url) {
-        if (publishers[to] !== undefined) {
-            var eoId = url + '_' + to;
-            log.info('message: Adding ExternalOutput, id: ' + eoId);
-            var externalOutput = new addon.ExternalOutput(url);
-            externalOutput.wrtcId = eoId;
-            externalOutput.init();
-            publishers[to].muxer.addExternalOutput(externalOutput, url);
-            externalOutputs[url] = externalOutput;
-        }
+      publishers[to] && publishers[to].addExternalOutput(url);
     };
 
     that.removeExternalOutput = function (to, url) {
-        if (externalOutputs[url] !== undefined && publishers[to] !== undefined) {
-            log.info('message: Stopping ExternalOutput, id: ' + externalOutputs[url].wrtcId);
-            publishers[to].muxer.removeSubscriber(url);
-            externalOutputs[url].close(function() {
-              log.info('message: ExternalOutput closed');
-              delete externalOutputs[url];
-            });
+        if (publishers[to] !== undefined) {
+            log.info('message: Stopping ExternalOutput, id: ' + publishers[to].getExternalOutput(url).wrtcId);
+            publishers[to].removeExternalOutput(url);
         }
     };
 
@@ -249,16 +216,18 @@ exports.ErizoJSController = function (threadPool) {
         log.info('message: Process Signaling message, ' +
                  'streamId: ' + streamId + ', peerId: ' + peerId, msg);
         if (publishers[streamId] !== undefined) {
-            if (subscribers[streamId][peerId]) {
+            var publisher = publishers[streamId];
+            if (publisher.hasSubscriber(peerId)) {
+                var subscriber = publisher.getSubscriber(peerId);
                 if (msg.type === 'offer') {
-                    subscribers[streamId][peerId].setRemoteSdp(msg.sdp);
+                    subscriber.setRemoteSdp(msg.sdp);
                 } else if (msg.type === 'candidate') {
-                    subscribers[streamId][peerId].addRemoteCandidate(msg.candidate.sdpMid,
+                    subscriber.addRemoteCandidate(msg.candidate.sdpMid,
                                                                      msg.candidate.sdpMLineIndex,
                                                                      msg.candidate.candidate);
                 } else if (msg.type === 'updatestream') {
                     if(msg.sdp)
-                        subscribers[streamId][peerId].setRemoteSdp(msg.sdp);
+                        subscriber.setRemoteSdp(msg.sdp);
                     if (msg.config) {
                         if (msg.config.slideShowMode !== undefined) {
                             that.setSlideShow(msg.config.slideShowMode, peerId, streamId);
@@ -270,27 +239,30 @@ exports.ErizoJSController = function (threadPool) {
                 }
             } else {
                 if (msg.type === 'offer') {
-                    publishers[streamId].wrtc.setRemoteSdp(msg.sdp);
+                    publisher.wrtc.setRemoteSdp(msg.sdp);
                 } else if (msg.type === 'candidate') {
-                    publishers[streamId].wrtc.addRemoteCandidate(msg.candidate.sdpMid,
+                    publisher.wrtc.addRemoteCandidate(msg.candidate.sdpMid,
                                                                  msg.candidate.sdpMLineIndex,
                                                                  msg.candidate.candidate);
                 } else if (msg.type === 'updatestream') {
                     if (msg.sdp) {
-                        publishers[streamId].wrtc.setRemoteSdp(msg.sdp);
+                        publisher.wrtc.setRemoteSdp(msg.sdp);
                     }
                     if (msg.config) {
                         if (msg.config.minVideoBW) {
                             log.debug('message: updating minVideoBW for publisher, ' +
                                       'id: ' + publishers[streamId].wrtcId + ', ' +
                                       'minVideoBW: ' + msg.config.minVideoBW);
-                            publishers[streamId].minVideoBW = msg.config.minVideoBW;
-                            for (var sub in subscribers[streamId]) {
-                                var theConn = subscribers[streamId][sub];
+                            publisher.minVideoBW = msg.config.minVideoBW;
+                            for (var sub in publisher.subscribers) {
+                                var theConn = publisher.getSubscriber(sub);
                                 theConn.minVideoBW = msg.config.minVideoBW * 1000; // bps
                                 theConn.lowerThres = Math.floor(theConn.minVideoBW*(1-0.2));
                                 theConn.upperThres = Math.ceil(theConn.minVideoBW*(1+0.1));
                             }
+                        }
+                        if (msg.config.muteStream !== undefined) {
+                            that.muteStream (msg.config.muteStream, peerId, streamId);
                         }
                     }
                 }
@@ -305,8 +277,7 @@ exports.ErizoJSController = function (threadPool) {
      * of the OneToManyProcessor.
      */
     that.addPublisher = function (from, options, callback) {
-        var muxer;
-        var wrtc;
+        var publisher;
 
         if (publishers[from] === undefined) {
 
@@ -314,58 +285,23 @@ exports.ErizoJSController = function (threadPool) {
                      'streamId: ' + from + ', ' +
                      logger.objectToLog(options) + ', ' +
                      logger.objectToLog(options.metadata));
-            var wrtcId = from;
-            muxer = new addon.OneToManyProcessor();
-            wrtc = new addon.WebRtcConnection(threadPool, wrtcId,
-                                              GLOBAL.config.erizo.stunserver,
-                                              GLOBAL.config.erizo.stunport,
-                                              GLOBAL.config.erizo.minport,
-                                              GLOBAL.config.erizo.maxport,
-                                              false,
-                                              JSON.stringify(GLOBAL.mediaConfig),
-                                              GLOBAL.config.erizo.turnserver,
-                                              GLOBAL.config.erizo.turnport,
-                                              GLOBAL.config.erizo.turnusername,
-                                              GLOBAL.config.erizo.turnpass);
-            wrtc.wrtcId = wrtcId;
+            publisher = new Publisher(from, threadPool, options);
+            publishers[from] = publisher;
 
-            publishers[from] = {muxer: muxer,
-                                wrtc: wrtc,
-                                minVideoBW: options.minVideoBW,
-                                scheme: options.scheme};
-            subscribers[from] = {};
-
-            wrtc.setAudioReceiver(muxer);
-            wrtc.setVideoReceiver(muxer);
-            muxer.setPublisher(wrtc);
-
-            initWebRtcConnection(wrtc, callback, from, undefined, options);
+            initWebRtcConnection(publisher.wrtc, callback, from, undefined, options);
 
         } else {
-            if (Object.keys(subscribers[from]).length === 0) {
+            publisher = publishers[from];
+            if (publisher.numSubscribers === 0) {
                 log.warn('message: publisher already set but no subscribers will republish, ' +
                          'code: ' + WARN_CONFLICT + ', streamId: ' + from + ', ' +
                          logger.objectToLog(options.metadata));
 
-                wrtc = new addon.WebRtcConnection(threadPool, from,
-                                                  GLOBAL.config.erizo.stunserver,
-                                                  GLOBAL.config.erizo.stunport,
-                                                  GLOBAL.config.erizo.minport,
-                                                  GLOBAL.config.erizo.maxport,
-                                                  false,
-                                                  JSON.stringify(GLOBAL.mediaConfig),
-                                                  GLOBAL.config.erizo.turnserver,
-                                                  GLOBAL.config.erizo.turnport,
-                                                  GLOBAL.config.erizo.turnusername,
-                                                  GLOBAL.config.erizo.turnpass);
-                muxer = publishers[from].muxer;
-                publishers[from].wrtc = wrtc;
-                wrtc.setAudioReceiver(muxer);
-                wrtc.setVideoReceiver(muxer);
-                muxer.setPublisher(wrtc);
 
-                initWebRtcConnection(wrtc, callback, from, undefined, options);
-            }else{
+                publisher.resetWrtc();
+
+                initWebRtcConnection(publisher.wrtc, callback, from, undefined, options);
+            } else {
                 log.warn('message: publisher already set has subscribers will ignore, ' +
                          'code: ' + WARN_CONFLICT + ', streamId: ' + from);
             }
@@ -378,69 +314,46 @@ exports.ErizoJSController = function (threadPool) {
      * OneToManyProcessor.
      */
     that.addSubscriber = function (from, to, options, callback) {
-
-        if (publishers[to] === undefined) {
+        var publisher = publishers[to]
+        if (publisher === undefined) {
             log.warn('message: addSubscriber to unknown publisher, ' +
                      'code: ' + WARN_NOT_FOUND + ', streamId: ' + to + ', clientId: ' + from +
                       ', ' + logger.objectToLog(options.metadata));
             //We may need to notify the clients
             return;
         }
-        if (subscribers[to][from] !== undefined) {
+        var subscriber = publisher.getSubscriber(from);
+        if (subscriber !== undefined) {
             log.warn('message: Duplicated subscription will resubscribe, ' +
                      'code: ' + WARN_CONFLICT + ', streamId: ' + to + ', clientId: ' + from+
                       ', ' + logger.objectToLog(options.metadata));
             that.removeSubscriber(from,to);
         }
-        var wrtcId = from + '_' + to;
-        log.info('message: Adding subscriber, id: ' + wrtcId + ', ' +
-                 logger.objectToLog(options)+
-                  ', ' + logger.objectToLog(options.metadata));
-        var wrtc = new addon.WebRtcConnection(threadPool, wrtcId,
-                                              GLOBAL.config.erizo.stunserver,
-                                              GLOBAL.config.erizo.stunport,
-                                              GLOBAL.config.erizo.minport,
-                                              GLOBAL.config.erizo.maxport,
-                                              false,
-                                              JSON.stringify(GLOBAL.mediaConfig),
-                                              GLOBAL.config.erizo.turnserver,
-                                              GLOBAL.config.erizo.turnport,
-                                              GLOBAL.config.erizo.turnusername,
-                                              GLOBAL.config.erizo.turnpass);
-
-        wrtc.wrtcId = wrtcId;
-        subscribers[to][from] = wrtc;
-        publishers[to].muxer.addSubscriber(wrtc, from);
-        wrtc.minVideoBW = publishers[to].minVideoBW;
-        log.debug('message: Setting scheme from publisher to subscriber, ' +
-                  'id: ' + wrtcId + ', scheme: ' + publishers[to].scheme+
-                   ', ' + logger.objectToLog(options.metadata));
-        wrtc.scheme = publishers[to].scheme;
-        initWebRtcConnection(wrtc, callback, to, from, options);
+        publisher.addSubscriber(from, options);
+        initWebRtcConnection(publisher.getSubscriber(from), callback, to, from, options);
     };
 
     /*
      * Removes a publisher from the room. This also deletes the associated OneToManyProcessor.
      */
     that.removePublisher = function (from) {
-        if (subscribers[from] !== undefined && publishers[from] !== undefined) {
+      var publisher = publishers[from];
+        if (publisher !== undefined) {
             log.info('message: Removing publisher, id: ' + from);
-            if(publishers[from].periodicPlis!==undefined) {
+            if (publisher.periodicPlis !== undefined) {
                 log.debug('message: clearing periodic PLIs for publisher, id: ' + from);
-                clearInterval (publishers[from].periodicPlis);
+                clearInterval (publisher.periodicPlis);
             }
-            for (var key in subscribers[from]) {
-                if (subscribers[from].hasOwnProperty(key)) {
-                    log.info('message: Removing subscriber, id: ' + subscribers[from][key].wrtcId);
-                    closeWebRtcConnection(subscribers[from][key]);
-                }
+            for (var key in publisher.subscribers) {
+                var subscriber = publisher.getSubscriber(key);
+                log.info('message: Removing subscriber, id: ' + subscriber.wrtcId);
+                closeWebRtcConnection(subscriber);
             }
-            closeWebRtcConnection(publishers[from].wrtc);
-            publishers[from].muxer.close(function(message) {
+            closeWebRtcConnection(publisher.wrtc);
+            publisher.muxer.close(function(message) {
                 log.info('message: muxer closed succesfully, ' +
                          'id: ' + from + ', ' +
                          logger.objectToLog(message));
-                delete subscribers[from];
                 delete publishers[from];
                 var count = 0;
                 for (var k in publishers) {
@@ -466,24 +379,24 @@ exports.ErizoJSController = function (threadPool) {
      * This also removes it from the associated OneToManyProcessor.
      */
     that.removeSubscriber = function (from, to) {
-
-        if (subscribers[to] && subscribers[to][from]) {
-            log.info('message: removing subscriber, id: ' + subscribers[to][from].wrtcId);
-            closeWebRtcConnection(subscribers[to][from]);
-            publishers[to].muxer.removeSubscriber(from);
-            delete subscribers[to][from];
+        var publisher = publishers[to];
+        if (publisher && publisher.hasSubscriber(from)) {
+            var subscriber = publisher.getSubscriber(from);
+            log.info('message: removing subscriber, id: ' + subscriber.wrtcId);
+            closeWebRtcConnection(subscriber);
+            publisher.removeSubscriber(from);
         }
 
-        if (publishers[to] && publishers[to].wrtc.periodicPlis !== undefined) {
-            for (var i in subscribers[to]) {
-                if(subscribers[to][i].slideShowMode === true) {
+        if (publisher && publisher.wrtc.periodicPlis !== undefined) {
+            for (var i in publisher.subscribers) {
+                if (publisher.getSubscriber(i).slideShowMode === true) {
                     return;
                 }
             }
             log.debug('message: clearing Pli interval as no more ' +
                       'slideshows subscribers are present');
-            clearInterval(publishers[to].wrtc.periodicPlis);
-            publishers[to].wrtc.periodicPlis = undefined;
+            clearInterval(publisher.wrtc.periodicPlis);
+            publisher.wrtc.periodicPlis = undefined;
         }
     };
 
@@ -492,14 +405,15 @@ exports.ErizoJSController = function (threadPool) {
      */
     that.removeSubscriptions = function (from) {
         log.info('message: removing subscriptions, peerId:', from);
-        for (var to in subscribers) {
-            if (subscribers.hasOwnProperty(to)) {
-                if (subscribers[to][from]) {
+        for (var to in publishers) {
+            if (publishers.hasOwnProperty(to)) {
+                var publisher = publishers[to];
+                var subscriber = publisher.getSubscriber(from);
+                if (subscriber) {
                     log.debug('message: removing subscription, ' +
-                              'id:', subscribers[to][from].wrtcId);
-                    closeWebRtcConnection(subscribers[to][from]);
-                    publishers[to].muxer.removeSubscriber(from);
-                    delete subscribers[to][from];
+                              'id:', subscriber.wrtcId);
+                    closeWebRtcConnection(subscriber);
+                    publisher.removeSubscriber(from);
                 }
             }
         }
@@ -510,7 +424,8 @@ exports.ErizoJSController = function (threadPool) {
      */
     that.setSlideShow = function (slideShowMode, from, to) {
         var wrtcPub;
-        var theWrtc = subscribers[to][from];
+        var publisher = publishers[to];
+        var theWrtc = publisher.getSubscriber(from);
         if (!theWrtc) {
             log.warn('message: wrtc not found for updating slideshow, ' +
                      'code: ' + WARN_NOT_FOUND + ', id: ' + from + '_' + to);
@@ -522,7 +437,7 @@ exports.ErizoJSController = function (threadPool) {
         if (slideShowMode === true) {
             theWrtc.setSlideShowMode(true);
             theWrtc.slideShowMode = true;
-            wrtcPub = publishers[to].wrtc;
+            wrtcPub = publisher.wrtc;
             if (wrtcPub.periodicPlis === undefined) {
                 wrtcPub.periodicPlis = setInterval(function () {
                     if(wrtcPub)
@@ -530,31 +445,31 @@ exports.ErizoJSController = function (threadPool) {
                 }, SLIDESHOW_TIME);
             }
         } else {
-            wrtcPub = publishers[to].wrtc;
+            wrtcPub = publisher.wrtc;
             for (var pliIndex = 0; pliIndex < PLIS_TO_RECOVER; pliIndex++) {
               wrtcPub.generatePLIPacket();
             }
 
             theWrtc.setSlideShowMode(false);
             theWrtc.slideShowMode = false;
-            if (publishers[to].wrtc.periodicPlis !== undefined) {
-                for (var i in subscribers[to]) {
-                    if (subscribers[to][i].slideShowMode === true) {
+            if (publisher.wrtc.periodicPlis !== undefined) {
+                for (var i in publisher.subscribers) {
+                    if (publisher.getSubscriber(i).slideShowMode === true) {
                         return;
                     }
                 }
                 log.debug('message: clearing PLI interval for publisher slideShow, ' +
-                          'id: ' + publishers[to].wrtc.wrtcId);
-                clearInterval(publishers[to].wrtc.periodicPlis);
-                publishers[to].wrtc.periodicPlis = undefined;
+                          'id: ' + publisher.wrtc.wrtcId);
+                clearInterval(publisher.wrtc.periodicPlis);
+                publisher.wrtc.periodicPlis = undefined;
             }
         }
 
     };
 
     that.muteStream = function (muteStreamInfo, from, to) {
-        var subscriberWrtc = subscribers[to][from];
-        if (!subscribers) {
+        var subscriberWrtc = publishers[to].getSubscriber(from);
+        if (!subscriberWrtc) {
             log.warn('message: wrtc not found for muteStream, ' +
                      'code: ' + WARN_NOT_FOUND + ', id: ' + from + '_' + to);
             return;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -34,6 +34,7 @@ exports.ErizoJSController = function (threadPool) {
         WARN_CONFLICT       = 409,
         WARN_PRECOND_FAILED = 412,
         WARN_BAD_CONNECTION = 502;
+    that.publishers = publishers;
 
     /*
      * Given a WebRtcConnection waits for the state CANDIDATES_GATHERED for set remote SDP.
@@ -468,12 +469,8 @@ exports.ErizoJSController = function (threadPool) {
     };
 
     that.muteStream = function (muteStreamInfo, from, to) {
-        var subscriberWrtc = publishers[to].getSubscriber(from);
-        if (!subscriberWrtc) {
-            log.warn('message: wrtc not found for muteStream, ' +
-                     'code: ' + WARN_NOT_FOUND + ', id: ' + from + '_' + to);
-            return;
-        }
+        var publisher = this.publishers[to];
+        var subscriberWrtc = publisher.hasSubscriber(from);
         if (muteStreamInfo.video === undefined) {
             muteStreamInfo.video = false;
         }
@@ -481,9 +478,11 @@ exports.ErizoJSController = function (threadPool) {
         if (muteStreamInfo.audio === undefined) {
             muteStreamInfo.audio = false;
         }
-
-        subscriberWrtc.muteStream(muteStreamInfo.video,
-            muteStreamInfo.audio);
+        if (publisher.hasSubscriber(from)) {
+          publisher.muteSubscriberStream(from, muteStreamInfo.video, muteStreamInfo.audio);
+        } else {
+          publisher.muteStream(muteStreamInfo.video, muteStreamInfo.audio);
+        }
     };
 
     return that;

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -1,0 +1,145 @@
+/*global require, exports, setInterval, clearInterval*/
+'use strict';
+var addon = require('./../../../erizoAPI/build/Release/addon');
+var logger = require('./../../common/logger').logger;
+
+// Logger
+var log = logger.getLogger('Publisher');
+
+function createWrtc(id, threadPool) {
+  return new addon.WebRtcConnection(threadPool, id,
+                                    GLOBAL.config.erizo.stunserver,
+                                    GLOBAL.config.erizo.stunport,
+                                    GLOBAL.config.erizo.minport,
+                                    GLOBAL.config.erizo.maxport,
+                                    false,
+                                    JSON.stringify(GLOBAL.mediaConfig),
+                                    GLOBAL.config.erizo.turnserver,
+                                    GLOBAL.config.erizo.turnport,
+                                    GLOBAL.config.erizo.turnusername,
+                                    GLOBAL.config.erizo.turnpass);
+}
+
+class Source {
+  constructor(id, threadPool) {
+    this.id = id;
+    this.threadPool = threadPool;
+    this.subscribers = {};
+    this.externalOutputs = {};
+
+    this.muxer = new addon.OneToManyProcessor();
+  }
+
+  get numSubscribers() {
+    return Object.keys(this.subscribers).length;
+  }
+
+  addSubscriber(id, options) {
+    var wrtcId = id + '_' + this.id;
+    log.info('message: Adding subscriber, id: ' + wrtcId + ', ' +
+             logger.objectToLog(options)+
+              ', ' + logger.objectToLog(options.metadata));
+    var wrtc = createWrtc(wrtcId, this.threadPool);
+    wrtc.wrtcId = wrtcId;
+    this.subscribers[id] = wrtc;
+    this.muxer.addSubscriber(wrtc, id);
+    wrtc.minVideoBW = this.minVideoBW;
+    log.debug('message: Setting scheme from publisher to subscriber, ' +
+              'id: ' + wrtcId + ', scheme: ' + this.scheme+
+               ', ' + logger.objectToLog(options.metadata));
+    wrtc.scheme = this.scheme;
+  }
+
+  removeSubscriber(id) {
+    this.muxer.removeSubscriber(id);
+    delete this.subscribers[id];
+  }
+
+  getSubscriber(id) {
+    return this.subscribers[id];
+  }
+
+  hasSubscriber(id) {
+    return this.subscribers[id] !== undefined;
+  }
+
+  addExternalOutput(url) {
+    var eoId = url + '_' + this.id;
+    log.info('message: Adding ExternalOutput, id: ' + eoId);
+    var externalOutput = new addon.ExternalOutput(url);
+    externalOutput.wrtcId = eoId;
+    externalOutput.init();
+    this.muxer.addExternalOutput(externalOutput, url);
+    this.externalOutputs[url] = externalOutput;
+  }
+
+  removeExternalOutput(url) {
+    var self = this;
+    this.muxer.removeSubscriber(url);
+    this.externalOutputs[url].close(function() {
+      log.info('message: ExternalOutput closed');
+      delete self.externalOutputs[url];
+    });
+  }
+
+  hasExternalOutput(url) {
+    return this.externalOutputs[url] !== undefined;
+  }
+
+  getExternalOutput(url) {
+    return this.externalOutputs[url];
+  }
+}
+
+class Publisher extends Source {
+  constructor(id, threadPool, options) {
+    super(id, threadPool);
+    this.wrtc = createWrtc(this.id, this.threadPool);
+    this.wrtc.wrtcId = id;
+
+    this.minVideoBW = options.minVideoBW;
+    this.scheme = options.scheme;
+
+    this.wrtc.setAudioReceiver(this.muxer);
+    this.wrtc.setVideoReceiver(this.muxer);
+    this.muxer.setPublisher(this.wrtc);
+  }
+
+  resetWrtc() {
+    if (this.numSubscribers > 0) {
+      return;
+    }
+    this.wrtc = createWrtc(this.id, this.threadPool);
+    this.wrtc.setAudioReceiver(this.muxer);
+    this.wrtc.setVideoReceiver(this.muxer);
+    this.muxer.setPublisher(this.wrtc);
+  }
+}
+
+class ExternalInput extends Source {
+  constructor(id, threadPool, url) {
+    super(id, threadPool);
+    var eiId = id + '_' + url;
+
+    log.info('message: Adding ExternalInput, id: ' + eiId);
+
+    var ei = new addon.ExternalInput(url);
+
+    this.ei = ei;
+    ei.wrtcId = eiId;
+
+    this.subscribers = {};
+    this.externalOutputs = {};
+
+    ei.setAudioReceiver(this.muxer);
+    ei.setVideoReceiver(this.muxer);
+    this.muxer.setExternalPublisher(ei);
+  }
+
+  init() {
+    return this.ei.init();
+  }
+}
+
+exports.Publisher = Publisher;
+exports.ExternalInput = ExternalInput;

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -26,7 +26,8 @@ class Source {
     this.threadPool = threadPool;
     this.subscribers = {};
     this.externalOutputs = {};
-
+    this.muteAudio = false;
+    this.muteVideo = false;
     this.muxer = new addon.OneToManyProcessor();
   }
 
@@ -48,6 +49,7 @@ class Source {
               'id: ' + wrtcId + ', scheme: ' + this.scheme+
                ', ' + logger.objectToLog(options.metadata));
     wrtc.scheme = this.scheme;
+    this.muteSubscriberStream(id, false, false);
   }
 
   removeSubscriber(id) {
@@ -88,6 +90,25 @@ class Source {
 
   getExternalOutput(url) {
     return this.externalOutputs[url];
+  }
+
+  muteStream(muteVideo, muteAudio) {
+    this.muteVideo = muteVideo;
+    this.muteAudio = muteAudio;
+    for (var subId in this.subscribers) {
+      var sub = this.getSubscriber(subId);
+      this.muteSubscriberStream(subId, sub.muteVideo, sub.muteAudio);
+    }
+  }
+
+  muteSubscriberStream(id, muteVideo, muteAudio) {
+    var subscriber = this.getSubscriber(id);
+    subscriber.muteVideo = muteVideo;
+    subscriber.muteAudio = muteAudio;
+    log.info('message: Mute Stream, video: ', this.muteVideo || muteVideo,
+                                 ', audio: ', this.muteAudio || muteAudio);
+    subscriber.muteStream(this.muteVideo || muteVideo,
+                          this.muteAudio || muteAudio);
   }
 }
 

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -361,6 +361,54 @@ describe('Erizo JS Controller', function() {
           expect(mocks.WebRtcConnection.setRemoteSdp.callCount).to.equal(1);
         });
 
+        it('should mute and unmute subscriber stream', function() {
+          controller.processSignaling(kArbitraryId, kArbitraryId2, {
+                      type: 'updatestream',
+                      config: {
+                        muteStream: {
+                          audio: true,
+                          video: false
+                        }
+                      }});
+
+          controller.processSignaling(kArbitraryId, kArbitraryId2, {
+                      type: 'updatestream',
+                      config: {
+                        muteStream: {
+                          audio: false,
+                          video: false
+                        }
+                      }});
+
+          expect(mocks.WebRtcConnection.muteStream.callCount).to.equal(3);
+          expect(mocks.WebRtcConnection.muteStream.args[1]).to.deep.equal([false, true]);
+          expect(mocks.WebRtcConnection.muteStream.args[2]).to.deep.equal([false, false]);
+        });
+
+        it('should mute and unmute publisher stream', function() {
+          controller.processSignaling(kArbitraryId, undefined, {
+                      type: 'updatestream',
+                      config: {
+                        muteStream: {
+                          audio: true,
+                          video: false
+                        }
+                      }});
+
+          controller.processSignaling(kArbitraryId, undefined, {
+                      type: 'updatestream',
+                      config: {
+                        muteStream: {
+                          audio: false,
+                          video: false
+                        }
+                      }});
+
+          expect(mocks.WebRtcConnection.muteStream.callCount).to.equal(3);
+          expect(mocks.WebRtcConnection.muteStream.args[1]).to.deep.equal([false, true]);
+          expect(mocks.WebRtcConnection.muteStream.args[2]).to.deep.equal([false, false]);
+        });
+
         it('should set slide show mode to true', function() {
           controller.processSignaling(kArbitraryId, kArbitraryId2, {
                       type: 'updatestream',

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -142,7 +142,8 @@ var reset = module.exports.reset = function() {
     createOffer: sinon.stub(),
     setRemoteSdp: sinon.stub(),
     addRemoteCandidate: sinon.stub(),
-    setSlideShowMode: sinon.stub()
+    setSlideShowMode: sinon.stub(),
+    muteStream: sinon.stub()
   };
 
   module.exports.ExternalInput = {


### PR DESCRIPTION
This PR aims to:

- [x]  Reduce locks in audio mute feature (Erizo)
- [x]  Create a single list of publishers in ErizoJS
- [x]  Add the possibility to mute audio from a publisher

With this PR we can mute audio from Publisher and it will stop sending bytes to all the subscribers, saving bandwidth in these cases.