### PR TITLE
Give the option to choose which network interface we will bind services

### DIFF
--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -71,7 +71,9 @@ NiceConnection::NiceConnection(boost::shared_ptr<LibNiceInterface> libnice, Medi
     for (unsigned int i = 1; i <= iceComponents_; i++) {
       comp_state_list_[i] = NICE_INITIAL;
     }
+    #if !GLIB_CHECK_VERSION(2, 35, 0)
     g_type_init();
+    #endif
   }
 
 NiceConnection::~NiceConnection() {
@@ -207,8 +209,11 @@ void NiceConnection::start() {
           (guint)iceConfig_.maxPort);
     }
 
-    if (!iceConfig_.public_ip.empty()) {
-      lib_nice_->NiceAgentAddLocalAddress(agent_, iceConfig_.public_ip.c_str());
+    if (!iceConfig_.network_interface.empty()) {
+      const char* public_ip = lib_nice_->NiceInterfacesGetIpForInterface(iceConfig_.network_interface.c_str());
+      if (public_ip) {
+        lib_nice_->NiceAgentAddLocalAddress(agent_, public_ip);
+      }
     }
 
     if (iceConfig_.turnServer.compare("") != 0 && iceConfig_.turnPort != 0) {

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -207,6 +207,10 @@ void NiceConnection::start() {
           (guint)iceConfig_.maxPort);
     }
 
+    if (!iceConfig_.public_ip.empty()) {
+      lib_nice_->NiceAgentAddLocalAddress(agent_, iceConfig_.public_ip.c_str());
+    }
+
     if (iceConfig_.turnServer.compare("") != 0 && iceConfig_.turnPort != 0) {
       ELOG_DEBUG("%s message: configuring TURN, turnServer: %s , turnPort: %d, turnUsername: %s, turnPass: %s",
                  toLog(), iceConfig_.turnServer.c_str(),
@@ -275,6 +279,9 @@ bool NiceConnection::setRemoteCandidates(const std::vector<CandidateInfo> &candi
         nice_cand_type = NICE_CANDIDATE_TYPE_HOST;
         break;
     }
+    if (cinfo.hostPort == 0) {
+      continue;
+    }
     NiceCandidate* thecandidate = nice_candidate_new(nice_cand_type);
     thecandidate->username = strdup(cinfo.username.c_str());
     thecandidate->password = strdup(cinfo.password.c_str());
@@ -336,6 +343,9 @@ void NiceConnection::getCandidate(uint stream_id, uint component_id, const std::
     cand_info.priority = cand->priority;
     cand_info.hostAddress = std::string(address);
     cand_info.hostPort = nice_address_get_port(&cand->addr);
+    if (cand_info.hostPort == 0) {
+      continue;
+    }
     cand_info.mediaType = mediaType;
 
     /*

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -46,7 +46,7 @@ struct CandidatePair{
 class IceConfig {
  public:
     std::string turnServer, turnUsername, turnPass;
-    std::string stunServer, public_ip;
+    std::string stunServer, network_interface;
     uint16_t stunPort, turnPort, minPort, maxPort;
     bool shouldTrickle;
     IceConfig(){
@@ -59,7 +59,7 @@ class IceConfig {
       minPort = 0;
       maxPort = 0;
       shouldTrickle = false;
-      public_ip = "";
+      network_interface = "";
     }
 };
 

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -46,7 +46,7 @@ struct CandidatePair{
 class IceConfig {
  public:
     std::string turnServer, turnUsername, turnPass;
-    std::string stunServer;
+    std::string stunServer, public_ip;
     uint16_t stunPort, turnPort, minPort, maxPort;
     bool shouldTrickle;
     IceConfig(){
@@ -59,6 +59,7 @@ class IceConfig {
       minPort = 0;
       maxPort = 0;
       shouldTrickle = false;
+      public_ip = "";
     }
 };
 

--- a/erizo/src/erizo/lib/LibNiceInterface.h
+++ b/erizo/src/erizo/lib/LibNiceInterface.h
@@ -21,6 +21,7 @@ class LibNiceInterface {
   virtual int NiceAgentAddStream(NiceAgent* agent, unsigned int n_components) = 0;
   virtual bool NiceAgentGetLocalCredentials(NiceAgent* agent, unsigned int stream_id,
       char** ufrag, char** pass) = 0;
+  virtual bool NiceAgentAddLocalAddress(NiceAgent* agent, const char *ip) = 0;
   virtual void NiceAgentSetPortRange(NiceAgent* agent, unsigned int stream_id,
       unsigned int component_id, unsigned int min_port, unsigned int max_port) = 0;
   virtual bool NiceAgentGetSelectedPair(NiceAgent* agent, unsigned int stream_id,
@@ -46,6 +47,7 @@ class LibNiceInterfaceImpl: public LibNiceInterface {
   int NiceAgentAddStream(NiceAgent* agent, unsigned int n_components);
   bool NiceAgentGetLocalCredentials(NiceAgent* agent, unsigned int stream_id,
       char** ufrag, char** pass);
+  bool NiceAgentAddLocalAddress(NiceAgent* agent, const char *ip);
   void NiceAgentSetPortRange(NiceAgent* agent, unsigned int stream_id,
       unsigned int component_id, unsigned int min_port, unsigned int max_port);
   bool NiceAgentGetSelectedPair(NiceAgent* agent, unsigned int stream_id,
@@ -66,4 +68,3 @@ class LibNiceInterfaceImpl: public LibNiceInterface {
 
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_LIB_LIBNICEINTERFACE_H_
-

--- a/erizo/src/erizo/lib/LibNiceInterface.h
+++ b/erizo/src/erizo/lib/LibNiceInterface.h
@@ -18,6 +18,7 @@ namespace erizo {
 class LibNiceInterface {
  public:
   virtual NiceAgent* NiceAgentNew(GMainContext* context) = 0;
+  virtual char* NiceInterfacesGetIpForInterface(const char *interface_name) = 0;
   virtual int NiceAgentAddStream(NiceAgent* agent, unsigned int n_components) = 0;
   virtual bool NiceAgentGetLocalCredentials(NiceAgent* agent, unsigned int stream_id,
       char** ufrag, char** pass) = 0;
@@ -45,6 +46,7 @@ class LibNiceInterfaceImpl: public LibNiceInterface {
  public:
   NiceAgent* NiceAgentNew(GMainContext* context);
   int NiceAgentAddStream(NiceAgent* agent, unsigned int n_components);
+  char* NiceInterfacesGetIpForInterface(const char *interface_name);
   bool NiceAgentGetLocalCredentials(NiceAgent* agent, unsigned int stream_id,
       char** ufrag, char** pass);
   bool NiceAgentAddLocalAddress(NiceAgent* agent, const char *ip);

--- a/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
+++ b/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
@@ -21,6 +21,12 @@ namespace erizo {
       unsigned int component_id, unsigned int min_port, unsigned int max_port) {
     return nice_agent_set_port_range(agent, stream_id, component_id, min_port, max_port);
   }
+  bool LibNiceInterfaceImpl::NiceAgentAddLocalAddress(NiceAgent* agent, const char *ip) {
+    NiceAddress addr;
+    nice_address_init(&addr);
+    nice_address_set_from_string(&addr, ip);
+    return nice_agent_add_local_address(agent, &addr);
+  }
   bool LibNiceInterfaceImpl::NiceAgentGetSelectedPair(NiceAgent* agent, unsigned int stream_id,
       unsigned int component_id, NiceCandidate** local, NiceCandidate** remote) {
     return nice_agent_get_selected_pair(agent, stream_id, component_id, local, remote);

--- a/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
+++ b/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
@@ -4,11 +4,15 @@
 
 #include "./LibNiceInterface.h"
 #include <nice/nice.h>
+#include <nice/interfaces.h>
 
 namespace erizo {
 
   NiceAgent* LibNiceInterfaceImpl::NiceAgentNew(GMainContext* context) {
     return nice_agent_new(context, NICE_COMPATIBILITY_RFC5245);
+  }
+  char* LibNiceInterfaceImpl::NiceInterfacesGetIpForInterface(const char *interface_name) {
+    return nice_interfaces_get_ip_for_interface(const_cast<char*>(interface_name));
   }
   int LibNiceInterfaceImpl::NiceAgentAddStream(NiceAgent* agent, unsigned int n_components) {
     return nice_agent_add_stream(agent, n_components);

--- a/erizo/src/test/NiceConnectionTest.cpp
+++ b/erizo/src/test/NiceConnectionTest.cpp
@@ -29,6 +29,7 @@ class MockLibNice: public erizo::LibNiceInterface {
 
   MOCK_METHOD1(NiceAgentNew, NiceAgent*(GMainContext*));
   MOCK_METHOD2(NiceAgentAddStream, int(NiceAgent*, unsigned int));
+  MOCK_METHOD2(NiceAgentAddLocalAddress, bool(NiceAgent* agent, const char *ip));
   MOCK_METHOD4(NiceAgentGetLocalCredentials, bool(NiceAgent*, unsigned int, char**, char**));
   MOCK_METHOD5(NiceAgentSetPortRange, void(NiceAgent*, unsigned int, unsigned int,
         unsigned int, unsigned int));

--- a/erizo/src/test/NiceConnectionTest.cpp
+++ b/erizo/src/test/NiceConnectionTest.cpp
@@ -28,6 +28,7 @@ class MockLibNice: public erizo::LibNiceInterface {
   }
 
   MOCK_METHOD1(NiceAgentNew, NiceAgent*(GMainContext*));
+  MOCK_METHOD1(NiceInterfacesGetIpForInterface, char*(const char *));
   MOCK_METHOD2(NiceAgentAddStream, int(NiceAgent*, unsigned int));
   MOCK_METHOD2(NiceAgentAddLocalAddress, bool(NiceAgent* agent, const char *ip));
   MOCK_METHOD4(NiceAgentGetLocalCredentials, bool(NiceAgent*, unsigned int, char**, char**));

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -142,13 +142,13 @@ NAN_METHOD(WebRtcConnection::New) {
       v8::String::Utf8Value param4(Nan::To<v8::String>(info[11]).ToLocalChecked());
       std::string turnPass = std::string(*param4);
       v8::String::Utf8Value param5(Nan::To<v8::String>(info[12]).ToLocalChecked());
-      std::string public_ip = std::string(*param5);
+      std::string network_interface = std::string(*param5);
 
       iceConfig.turnServer = turnServer;
       iceConfig.turnPort = turnPort;
       iceConfig.turnUsername = turnUsername;
       iceConfig.turnPass = turnPass;
-      iceConfig.public_ip = public_ip;
+      iceConfig.network_interface = network_interface;
     }
 
 

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -131,7 +131,7 @@ NAN_METHOD(WebRtcConnection::New) {
     }
 
     erizo::IceConfig iceConfig;
-    if (info.Length() == 12) {
+    if (info.Length() == 13) {
       v8::String::Utf8Value param2(Nan::To<v8::String>(info[8]).ToLocalChecked());
       std::string turnServer = std::string(*param2);
       int turnPort = info[9]->IntegerValue();
@@ -139,10 +139,14 @@ NAN_METHOD(WebRtcConnection::New) {
       std::string turnUsername = std::string(*param3);
       v8::String::Utf8Value param4(Nan::To<v8::String>(info[11]).ToLocalChecked());
       std::string turnPass = std::string(*param4);
+      v8::String::Utf8Value param5(Nan::To<v8::String>(info[12]).ToLocalChecked());
+      std::string public_ip = std::string(*param5);
+
       iceConfig.turnServer = turnServer;
       iceConfig.turnPort = turnPort;
       iceConfig.turnUsername = turnUsername;
       iceConfig.turnPass = turnPass;
+      iceConfig.public_ip = public_ip;
     }
 
 

--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -33,7 +33,13 @@ var getopt = new Getopt([
   ['h' , 'help'                       , 'display this help']
 ]);
 
-var publicIP;
+var interfaces = require('os').networkInterfaces(),
+    addresses = [],
+    k,
+    k2,
+    address,
+    privateIP,
+    publicIP;
 
 var opt = getopt.parse(process.argv.slice(2));
 
@@ -128,10 +134,10 @@ launchErizoJS = function() {
     if (GLOBAL.config.erizoAgent.useIndividualLogFiles){
         out = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');
         err = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');
-        erizoProcess = spawn('./launch.sh', ['./../erizoJS/erizoJS.js', id, publicIP],
+        erizoProcess = spawn('./launch.sh', ['./../erizoJS/erizoJS.js', id, privateIP, publicIP],
                              { detached: true, stdio: [ 'ignore', out, err ] });
     }else{
-        erizoProcess = spawn('./launch.sh', ['./../erizoJS/erizoJS.js', id, publicIP],
+        erizoProcess = spawn('./launch.sh', ['./../erizoJS/erizoJS.js', id, privateIP, publicIP],
                             { detached: true, stdio: [ 'ignore', 'pipe', 'pipe' ] });
         erizoProcess.stdout.setEncoding('utf8');
         erizoProcess.stdout.on('data', function (message) {
@@ -243,21 +249,47 @@ var api = {
     getErizoAgents: reporter.getErizoAgent
 };
 
-if (global.config.cloudProvider.name === 'amazon') {
-    var AWS = require('aws-sdk');
-    new AWS.MetadataService({
-        httpOptions: {
-            timeout: 5000
+for (k in interfaces) {
+    if (interfaces.hasOwnProperty(k)) {
+      if (!GLOBAL.config.erizoAgent.networkinterface ||
+          GLOBAL.config.erizoAgent.networkinterface === k) {
+        for (k2 in interfaces[k]) {
+            if (interfaces[k].hasOwnProperty(k2)) {
+                address = interfaces[k][k2];
+                if (address.family === 'IPv4' && !address.internal) {
+                    if (k === BINDED_INTERFACE_NAME || !BINDED_INTERFACE_NAME) {
+                        addresses.push(address.address);
+                    }
+                }
+            }
         }
-    }).request('/latest/meta-data/public-ipv4', function(err, data) {
-        if (err) {
-            log.info('Error: ', err);
-        } else {
-            log.info('Got public ip: ', data);
-            publicIP = data;
-            fillErizos();
-        }
-    });
+      }
+    }
+}
+
+privateIP = addresses[0];
+
+if (GLOBAL.config.erizoAgent.publicIP === '' || GLOBAL.config.erizoAgent.publicIP === undefined) {
+    publicIP = addresses[0];
+
+    if (global.config.cloudProvider.name === 'amazon') {
+        var AWS = require('aws-sdk');
+        new AWS.MetadataService({
+            httpOptions: {
+                timeout: 5000
+            }
+        }).request('/latest/meta-data/public-ipv4', function(err, data) {
+            if (err) {
+                log.info('Error: ', err);
+            } else {
+                log.info('Got public ip: ', data);
+                publicIP = data;
+                fillErizos();
+            }
+        });
+    } else {
+        fillErizos();
+    }
 } else {
     publicIP = GLOBAL.config.erizoAgent.publicIP;
     fillErizos();

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -193,19 +193,21 @@ var addToCloudHandler = function (callback) {
         k2,
         address;
 
-
     for (k in interfaces) {
-        if (interfaces.hasOwnProperty(k)) {
-            for (k2 in interfaces[k]) {
-                if (interfaces[k].hasOwnProperty(k2)) {
-                    address = interfaces[k][k2];
-                    if (address.family === 'IPv4' && !address.internal) {
-                        if (k === BINDED_INTERFACE_NAME || !BINDED_INTERFACE_NAME) {
-                            addresses.push(address.address);
-                        }
-                    }
-                }
-            }
+        if (!GLOBAL.config.erizoController.networkinterface ||
+            GLOBAL.config.erizoController.networkinterface === k) {
+          if (interfaces.hasOwnProperty(k)) {
+              for (k2 in interfaces[k]) {
+                  if (interfaces[k].hasOwnProperty(k2)) {
+                      address = interfaces[k][k2];
+                      if (address.family === 'IPv4' && !address.internal) {
+                          if (k === BINDED_INTERFACE_NAME || !BINDED_INTERFACE_NAME) {
+                              addresses.push(address.address);
+                          }
+                      }
+                  }
+              }
+          }
         }
     }
 
@@ -978,7 +980,7 @@ var listen = function () {
                 updateMyState();
             }
         });
-        
+
         socket.on('getStreamStats', function (streamId, callback) {
             log.debug('Getting stats for streamId ' + streamId);
             if (socket.user === undefined || !socket.user.permissions[Permission.STATS]) {

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -16,6 +16,7 @@ GLOBAL.config.erizo.turnserver = GLOBAL.config.erizo.turnserver || '';
 GLOBAL.config.erizo.turnport = GLOBAL.config.erizo.turnport || 0;
 GLOBAL.config.erizo.turnusername = GLOBAL.config.erizo.turnusername || '';
 GLOBAL.config.erizo.turnpass = GLOBAL.config.erizo.turnpass || '';
+GLOBAL.config.erizo.networkinterface = GLOBAL.config.erizo.networkinterface || '';
 GLOBAL.mediaConfig = mediaConfig || {};
 // Parse command line arguments
 var getopt = new Getopt([
@@ -79,12 +80,13 @@ var threadPool = new addon.ThreadPool(GLOBAL.config.erizo.numWorkers);
 threadPool.start();
 
 var ejsController = controller.ErizoJSController(threadPool);
-GLOBAL.ejsController = ejsController;
+
 ejsController.keepAlive = function(callback) {
     callback('callback', true);
 };
 
-ejsController.publicIP = process.argv[3];
+ejsController.privateRegexp = new RegExp(process.argv[3], 'g');
+ejsController.publicIP = process.argv[4];
 
 amqper.connect(function () {
     try {

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -79,13 +79,12 @@ var threadPool = new addon.ThreadPool(GLOBAL.config.erizo.numWorkers);
 threadPool.start();
 
 var ejsController = controller.ErizoJSController(threadPool);
-
+GLOBAL.ejsController = ejsController;
 ejsController.keepAlive = function(callback) {
     callback('callback', true);
 };
 
-ejsController.privateRegexp = new RegExp(process.argv[3], 'g');
-ejsController.publicIP = process.argv[4];
+ejsController.publicIP = process.argv[3];
 
 amqper.connect(function () {
     try {

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -99,6 +99,7 @@ exports.ErizoJSController = function (threadPool) {
 
                 case CONN_SDP:
                 case CONN_GATHERED:
+                    mess = mess.replace(that.privateRegexp, that.publicIP);
                     if (options.createOffer)
                         callback('callback', {type: 'offer', sdp: mess});
                     else
@@ -106,6 +107,7 @@ exports.ErizoJSController = function (threadPool) {
                     break;
 
                 case CONN_CANDIDATE:
+                    mess = mess.replace(that.privateRegexp, that.publicIP);
                     callback('callback', {type: 'candidate', candidate: mess});
                     break;
 
@@ -301,7 +303,7 @@ exports.ErizoJSController = function (threadPool) {
                      'streamId: ' + from + ', ' +
                      logger.objectToLog(options) + ', ' +
                      logger.objectToLog(options.metadata));
-            publisher = new Publisher(from, threadPool, that.publicIP, options);
+            publisher = new Publisher(from, threadPool, options);
             publishers[from] = publisher;
 
             initWebRtcConnection(publisher.wrtc, callback, from, undefined, options);

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -99,7 +99,6 @@ exports.ErizoJSController = function (threadPool) {
 
                 case CONN_SDP:
                 case CONN_GATHERED:
-                    mess = mess.replace(that.privateRegexp, that.publicIP);
                     if (options.createOffer)
                         callback('callback', {type: 'offer', sdp: mess});
                     else
@@ -107,7 +106,6 @@ exports.ErizoJSController = function (threadPool) {
                     break;
 
                 case CONN_CANDIDATE:
-                    mess = mess.replace(that.privateRegexp, that.publicIP);
                     callback('callback', {type: 'candidate', candidate: mess});
                     break;
 
@@ -286,7 +284,7 @@ exports.ErizoJSController = function (threadPool) {
                      'streamId: ' + from + ', ' +
                      logger.objectToLog(options) + ', ' +
                      logger.objectToLog(options.metadata));
-            publisher = new Publisher(from, threadPool, options);
+            publisher = new Publisher(from, threadPool, that.publicIP, options);
             publishers[from] = publisher;
 
             initWebRtcConnection(publisher.wrtc, callback, from, undefined, options);

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -8,7 +8,7 @@ var log = logger.getLogger('Publisher');
 
 function createWrtc(id, threadPool, publicIP) {
   publicIP = publicIP || "";
-  var new addon.WebRtcConnection(threadPool, id,
+  var wrtc = new addon.WebRtcConnection(threadPool, id,
                                     GLOBAL.config.erizo.stunserver,
                                     GLOBAL.config.erizo.stunport,
                                     GLOBAL.config.erizo.minport,

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -58,6 +58,7 @@ config.erizoController.maxVideoBW = 300; //default value: 300
 // Public erizoController IP for websockets (useful when behind NATs)
 // Use '' to automatically get IP from the interface
 config.erizoController.publicIP = ''; //default value: ''
+config.erizoController.networkinterface = ''; //default value: ''
 
 // This configuration is used by the clients to reach erizoController
 // Use '' to use the public IP address instead of a hostname
@@ -115,6 +116,7 @@ config.erizoAgent.prerunProcesses = 1; // default value: 1
 // Public erizoAgent IP for ICE candidates (useful when behind NATs)
 // Use '' to automatically get IP from the interface
 config.erizoAgent.publicIP = ''; //default value: ''
+config.erizoAgent.networkinterface = ''; //default value: ''
 
 // Use the name of the inferface you want to bind for ICE candidates
 // config.erizoAgent.networkInterface = 'eth1' // default value: undefined
@@ -154,6 +156,7 @@ config.erizo.turnserver = ''; // default value: ''
 config.erizo.turnport = 0; // default value: 0
 config.erizo.turnusername = '';
 config.erizo.turnpass = '';
+config.erizo.networkinterface = ''; //default value: ''
 
 //note, this won't work with all versions of libnice. With 0 all the available ports are used
 config.erizo.minport = 0; // default value: 0


### PR DESCRIPTION
Not needed to merge this now, it's something I've needed during the latest weeks to run Licode inside Vagrant using multiple interfaces. 

The reason to add it it that it might be needed in some cases, especially when servers have multiple network interfaces.

- [x] I think it keeps working right in Amazon EC2, but I need to do further tests yet.