### PR TITLE
Add support to Transport CC header extensions

### DIFF
--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -86,6 +86,9 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
       case VIDEO_ORIENTATION:
         type = webrtc::kRtpExtensionVideoRotation;
         break;
+      case TRANSPORT_CC:
+        type = webrtc::kRtpExtensionTransportSequenceNumber;
+        break;
       case PLAYBACK_TIME:
         type = webrtc::kRtpExtensionPlayoutDelay;
         break;

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
@@ -15,6 +15,7 @@ RtpExtensionProcessor::RtpExtensionProcessor() {
   translationMap_["http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"] = ABS_SEND_TIME;
   translationMap_["urn:ietf:params:rtp-hdrext:toffset"] = TOFFSET;
   translationMap_["urn:3gpp:video-orientation"] = VIDEO_ORIENTATION;
+  translationMap_["http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"] = TRANSPORT_CC;
   translationMap_["http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"]= PLAYBACK_TIME;
   ext_map_video_.fill(UNKNOWN);
   ext_map_audio_.fill(UNKNOWN);

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.h
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.h
@@ -18,6 +18,7 @@ enum RTPExtensions {
   ABS_SEND_TIME,        // http:// www.webrtc.org/experiments/rtp-hdrext/abs-send-time
   TOFFSET,              // urn:ietf:params:rtp-hdrext:toffset
   VIDEO_ORIENTATION,    // urn:3gpp:video-orientation
+  TRANSPORT_CC,    // http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
   PLAYBACK_TIME         //  http:// www.webrtc.org/experiments/rtp-hdrext/playout-delay
 };
 

--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -143,6 +143,10 @@ launchErizoJS = function() {
         erizoProcess.stdout.on('data', function (message) {
             console.log('[erizo-' + id + ']',message.replace (/\n$/,''));
         });
+        erizoProcess.stderr.setEncoding('utf8');
+        erizoProcess.stderr.on('data', function (message) {
+            console.log('[erizo-' + id + ']',message.replace (/\n$/,''));
+        });
     }
     erizoProcess.unref();
     erizoProcess.on('close', function () {

--- a/erizo_controller/test/erizoAgent/erizoAgent.js
+++ b/erizo_controller/test/erizoAgent/erizoAgent.js
@@ -74,6 +74,8 @@ describe('Erizo Agent', function() {
       expect(childProcessMock.spawn.callCount).to.equal(kArbitraryPrerunProcesses);
       expect(spawnMock.stdout.setEncoding.callCount).to.equal(kArbitraryPrerunProcesses);
       expect(spawnMock.stdout.on.callCount).to.equal(kArbitraryPrerunProcesses);
+      expect(spawnMock.stderr.setEncoding.callCount).to.equal(kArbitraryPrerunProcesses);
+      expect(spawnMock.stderr.on.callCount).to.equal(kArbitraryPrerunProcesses);
       expect(fsMock.openSync.callCount).to.equal(0);
       for (var index = 0; index < kArbitraryPrerunProcesses; index++) {
         expect(childProcessMock.spawn.args[index][0]).to.equal('./launch.sh');

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -38,6 +38,10 @@ var reset = module.exports.reset = function() {
       setEncoding: sinon.stub(),
       on: sinon.stub()
     },
+    stderr: {
+      setEncoding: sinon.stub(),
+      on: sinon.stub()
+    },
     on: sinon.stub(),
     unref: sinon.stub(),
     kill: sinon.stub()


### PR DESCRIPTION
There are two issues fixed here:
- We were not properly handling transport-cc extensions internally.
- We were not piping error messages from ErizoJS processes to the single log file.