### PR TITLE
Handlers con now be disabled by configuration

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -53,6 +53,11 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
   pipeline_->addFront(PacketWriter(this));
   pipeline_->finalize();
 
+  // TODO(javierc): we need to improve this mechanism to enable/disable handlers using the same pipeline
+  handlers_.push_back(audio_mute_handler_);
+  handlers_.push_back(slideshow_handler_);
+  handlers_.push_back(bwe_handler_);
+
   trickleEnabled_ = iceConfig_.shouldTrickle;
 
   shouldSendFeedback_ = true;
@@ -712,6 +717,44 @@ void WebRtcConnection::write(std::shared_ptr<dataPacket> packet) {
   }
   this->extProcessor_.processRtpExtensions(packet);
   transport->write(packet->data, packet->length);
+}
+
+std::shared_ptr<Handler> WebRtcConnection::getHandler(const std::string &name) {
+  std::shared_ptr<Handler> handler;
+  auto it = std::find_if(handlers_.begin(), handlers_.end(), [&name](std::shared_ptr<Handler> handler) {
+    return handler->getName() == name;
+  });
+  if (it != handlers_.end()) {
+    handler = *it;
+  }
+  return handler;
+}
+
+void WebRtcConnection::enableHandler(const std::string &name) {
+  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn){
+    auto handler = conn->getHandler(name);
+    if (handler.get()) {
+      handler->enable();
+    }
+  });
+}
+
+void WebRtcConnection::disableHandler(const std::string &name) {
+  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn){
+    auto handler = conn->getHandler(name);
+    if (handler.get()) {
+      handler->disable();
+    }
+  });
+}
+
+void WebRtcConnection::asyncTask(std::function<void(std::shared_ptr<WebRtcConnection>)> f) {
+  std::weak_ptr<WebRtcConnection> weak_this = shared_from_this();
+  worker_->task([weak_this, f] {
+    if (auto this_ptr = weak_this.lock()) {
+      f(this_ptr);
+    }
+  });
 }
 
 void WebRtcConnection::sendPacket(std::shared_ptr<dataPacket> p) {

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -156,6 +156,12 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   void read(std::shared_ptr<dataPacket> packet);
   void write(std::shared_ptr<dataPacket> packet);
 
+  void enableHandler(const std::string &name);
+  void disableHandler(const std::string &name);
+  std::shared_ptr<Handler> getHandler(const std::string &name);
+
+  void asyncTask(std::function<void(std::shared_ptr<WebRtcConnection>)> f);
+
   inline const char* toLog() {
     return ("id: " + connection_id_ + ", " + printLogContext()).c_str();
   }
@@ -180,6 +186,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
 
   int stunPort_, minPort_, maxPort_;
   std::string stunServer_;
+  std::vector<std::shared_ptr<Handler>> handlers_;
 
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
   boost::condition_variable cond_;
@@ -220,6 +227,13 @@ class PacketReader : public InboundHandler {
  public:
   explicit PacketReader(WebRtcConnection *connection) : connection_{connection} {}
 
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+    return "reader";
+  }
+
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override {
     connection_->read(packet);
   }
@@ -231,6 +245,13 @@ class PacketReader : public InboundHandler {
 class PacketWriter : public OutboundHandler {
  public:
   explicit PacketWriter(WebRtcConnection *connection) : connection_{connection} {}
+
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+    return "writer";
+  }
 
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override {
     connection_->write(packet);

--- a/erizo/src/erizo/pipeline/Handler.h
+++ b/erizo/src/erizo/pipeline/Handler.h
@@ -11,6 +11,7 @@
 #define ERIZO_SRC_ERIZO_PIPELINE_HANDLER_H_
 
 #include <cassert>
+#include <string>
 
 #include "pipeline/Pipeline.h"
 #include "./MediaDefinitions.h"
@@ -46,6 +47,10 @@ class Handler : public HandlerBase<HandlerContext> {
   typedef HandlerContext Context;
   virtual ~Handler() = default;
 
+  virtual void enable() = 0;
+  virtual void disable() = 0;
+  virtual std::string getName() = 0;
+
   virtual void read(Context* ctx, std::shared_ptr<dataPacket> packet) = 0;
   virtual void readEOF(Context* ctx) {
     ctx->fireReadEOF();
@@ -70,6 +75,11 @@ class InboundHandler : public HandlerBase<InboundHandlerContext> {
   typedef InboundHandlerContext Context;
   virtual ~InboundHandler() = default;
 
+  virtual void enable() = 0;
+  virtual void disable() = 0;
+
+  virtual std::string getName() = 0;
+
   virtual void read(Context* ctx, std::shared_ptr<dataPacket> packet) = 0;
   virtual void readEOF(Context* ctx) {
     ctx->fireReadEOF();
@@ -89,6 +99,11 @@ class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
   typedef OutboundHandlerContext Context;
   virtual ~OutboundHandler() = default;
 
+  virtual void enable() = 0;
+  virtual void disable() = 0;
+
+  virtual std::string getName() = 0;
+
   virtual void write(Context* ctx, std::shared_ptr<dataPacket> packet) = 0;
   virtual void close(Context* ctx) {
     return ctx->fireClose();
@@ -98,6 +113,16 @@ class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
 class HandlerAdapter : public Handler {
  public:
   typedef typename Handler::Context Context;
+
+  void enable() override {
+  }
+
+  void disable() override {
+  }
+
+  std::string getName() override {
+    return "adapter";
+  }
 
   void read(Context* ctx, std::shared_ptr<dataPacket> packet) override {
     ctx->fireRead(packet);

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -47,7 +47,15 @@ BandwidthEstimationHandler::BandwidthEstimationHandler(WebRtcConnection *connect
   using_absolute_send_time_{false}, packets_since_absolute_send_time_{0},
   min_bitrate_bps_{kMinBitRateAllowed}, temp_ctx_{nullptr},
   bitrate_{0}, last_send_bitrate_{0}, last_remb_time_{0},
-  running_{false} {
+  running_{false}, active_{true} {
+}
+
+void BandwidthEstimationHandler::enable() {
+  active_ = true;
+}
+
+void BandwidthEstimationHandler::disable() {
+  active_ = false;
 }
 
 void BandwidthEstimationHandler::process() {
@@ -183,7 +191,7 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   remb_packet_.setREMBNumSSRC(1);
   remb_packet_.setREMBFeedSSRC(connection_->getVideoSourceSSRC());
   int remb_length = (remb_packet_.getLength() + 1) * 4;
-  if (temp_ctx_) {
+  if (temp_ctx_ && active_) {
     ELOG_TRACE("BWE Estimation is %d", last_send_bitrate_);
     temp_ctx_->fireWrite(std::make_shared<dataPacket>(0,
       reinterpret_cast<char*>(&remb_packet_), remb_length, OTHER_PACKET));

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <vector>
+#include <string>
 
 #include "./logger.h"
 #include "pipeline/Handler.h"
@@ -42,6 +43,13 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   void OnReceiveBitrateChanged(const std::vector<uint32_t>& ssrcs,
                                        uint32_t bitrate) override;
 
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "bwe";
+  }
+
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
 
@@ -72,6 +80,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   uint32_t bitrate_, last_send_bitrate_;
   uint64_t last_remb_time_;
   bool running_;
+  bool active_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.cpp
@@ -9,6 +9,13 @@ DEFINE_LOGGER(RtpAudioMuteHandler, "rtp.RtpAudioMuteHandler");
 RtpAudioMuteHandler::RtpAudioMuteHandler(WebRtcConnection *connection) :
   last_original_seq_num_{-1}, seq_num_offset_{0}, mute_is_active_{false}, connection_{connection} {}
 
+
+void RtpAudioMuteHandler::enable() {
+}
+
+void RtpAudioMuteHandler::disable() {
+}
+
 void RtpAudioMuteHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
   if (connection_->getAudioSinkSSRC() != chead->getSourceSSRC()) {

--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
@@ -17,6 +17,13 @@ class RtpAudioMuteHandler: public Handler {
   explicit RtpAudioMuteHandler(WebRtcConnection* connection);
   void muteAudio(bool active);
 
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "audio-mute";
+  }
+
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
 

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -9,6 +9,13 @@ RtpRetransmissionHandler::RtpRetransmissionHandler(WebRtcConnection *connection)
   audio_{kRetransmissionsBufferSize},
   video_{kRetransmissionsBufferSize} {}
 
+
+void RtpRetransmissionHandler::enable() {
+}
+
+void RtpRetransmissionHandler::disable() {
+}
+
 void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   // ELOG_DEBUG("%p READING %d bytes", this, packet->length);
   bool contains_nack = false;

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
@@ -17,8 +17,14 @@ class RtpRetransmissionHandler : public Handler {
 
   explicit RtpRetransmissionHandler(WebRtcConnection *connection);
 
-  void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void enable() override;
+  void disable() override;
 
+  std::string getName() override {
+    return "retransmissions";
+  }
+
+  void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
 
  private:

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -1,6 +1,8 @@
 #ifndef ERIZO_SRC_ERIZO_RTP_RTPSLIDESHOWHANDLER_H_
 #define ERIZO_SRC_ERIZO_RTP_RTPSLIDESHOWHANDLER_H_
 
+#include <string>
+
 #include "pipeline/Handler.h"
 #include "./WebRtcConnection.h"
 
@@ -9,6 +11,10 @@ class RtpSlideShowHandler: public Handler {
  public:
   explicit RtpSlideShowHandler(WebRtcConnection* connection) : connection_{connection} {};
   virtual void setSlideShowMode(bool activated) = 0;
+
+  virtual void enable() = 0;
+  virtual void disable() = 0;
+  virtual std::string getName() = 0;
 
   virtual void read(Context *ctx, std::shared_ptr<dataPacket> packet) = 0;
   virtual void write(Context *ctx, std::shared_ptr<dataPacket> packet) = 0;

--- a/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.cpp
@@ -10,6 +10,13 @@ RtpVP8SlideShowHandler::RtpVP8SlideShowHandler(WebRtcConnection *connection) : R
   slideshow_seq_num_{-1}, last_original_seq_num_{-1}, seq_num_offset_{0}, slideshow_is_active_{false},
   sending_keyframe_ {false} {}
 
+
+void RtpVP8SlideShowHandler::enable() {
+}
+
+void RtpVP8SlideShowHandler::disable() {
+}
+
 void RtpVP8SlideShowHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
   if (connection_->getVideoSinkSSRC() != chead->getSourceSSRC()) {

--- a/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.h
@@ -2,6 +2,7 @@
 #define ERIZO_SRC_ERIZO_RTP_RTPVP8SLIDESHOWHANDLER_H_
 
 #include <boost/thread/mutex.hpp>
+#include <string>
 
 #include "pipeline/Handler.h"
 #include "./logger.h"
@@ -16,9 +17,15 @@ class RtpVP8SlideShowHandler : public RtpSlideShowHandler {
   explicit RtpVP8SlideShowHandler(WebRtcConnection* connection);
   void setSlideShowMode(bool activated) override;
 
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "slideshow-vp8";
+  }
+
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
-
 
  private:
   int32_t slideshow_seq_num_, last_original_seq_num_;

--- a/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
+++ b/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <queue>
+#include <string>
 #include <thread>  // NOLINT
 
 #include <rtp/RtpAudioMuteHandler.h>
@@ -110,11 +111,17 @@ class MockRemoteBitrateEstimator : public RemoteBitrateEstimator {
 
 class Reader : public InboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(read, void(Context*, std::shared_ptr<dataPacket>));
 };
 
 class Writer : public OutboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(write, void(Context*, std::shared_ptr<dataPacket>));
 };
 

--- a/erizo/src/test/rtp/RtpAudioMuteHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpAudioMuteHandlerTest.cpp
@@ -7,6 +7,7 @@
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
 
+#include <string>
 #include <vector>
 
 static constexpr uint16_t kVideoSsrc = 1;
@@ -43,11 +44,17 @@ class MockWebRtcConnection: public WebRtcConnection {
 
 class Reader : public InboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(read, void(Context*, std::shared_ptr<dataPacket>));
 };
 
 class Writer : public OutboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(write, void(Context*, std::shared_ptr<dataPacket>));
 };
 

--- a/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
@@ -7,6 +7,7 @@
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
 
+#include <string>
 #include <vector>
 
 static constexpr uint16_t kVideoSsrc = 1;
@@ -44,11 +45,17 @@ class MockWebRtcConnection: public WebRtcConnection {
 
 class Reader : public InboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(read, void(Context*, std::shared_ptr<dataPacket>));
 };
 
 class Writer : public OutboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(write, void(Context*, std::shared_ptr<dataPacket>));
 };
 

--- a/erizo/src/test/rtp/RtpVP8SlideShowHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpVP8SlideShowHandlerTest.cpp
@@ -9,6 +9,7 @@
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
 
+#include <string>
 #include <vector>
 
 static constexpr uint16_t kVideoSsrc = 1;
@@ -49,11 +50,17 @@ class MockWebRtcConnection: public WebRtcConnection {
 
 class Reader : public InboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(read, void(Context*, std::shared_ptr<dataPacket>));
 };
 
 class Writer : public OutboundHandler {
  public:
+  MOCK_METHOD0(enable, void());
+  MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(write, void(Context*, std::shared_ptr<dataPacket>));
 };
 
@@ -299,4 +306,3 @@ TEST_F(RtpVP8SlideShowHandlerTest, shouldAdjustSequenceNumberAfterSlideShow) {
     auto receiver_report = createReceiverReport(kArbitrarySeqNumber + packets_after_handler, VIDEO_PACKET);
     pipeline->read(receiver_report);
 }
-

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -50,6 +50,8 @@ NAN_MODULE_INIT(WebRtcConnection::Init) {
   Nan::SetPrototypeMethod(tpl, "setSlideShowMode", setSlideShowMode);
   Nan::SetPrototypeMethod(tpl, "muteStream", muteStream);
   Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
+  Nan::SetPrototypeMethod(tpl, "enableHandler", enableHandler);
+  Nan::SetPrototypeMethod(tpl, "disableHandler", disableHandler);
 
   constructor.Reset(tpl->GetFunction());
   Nan::Set(target, Nan::New("WebRtcConnection").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -339,6 +341,28 @@ NAN_METHOD(WebRtcConnection::generatePLIPacket) {
 
   std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
   me->sendPLI();
+  return;
+}
+
+NAN_METHOD(WebRtcConnection::enableHandler) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
+
+  v8::String::Utf8Value param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string name = std::string(*param);
+
+  me->enableHandler(name);
+  return;
+}
+
+NAN_METHOD(WebRtcConnection::disableHandler) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
+
+  v8::String::Utf8Value param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string name = std::string(*param);
+
+  me->disableHandler(name);
   return;
 }
 

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -122,6 +122,16 @@ class WebRtcConnection : public MediaSink, public erizo::WebRtcConnectionEventLi
      * Param: An object with metadata {key1:value1, key2: value2}
      */
     static NAN_METHOD(setMetadata);
+    /*
+     * Enable a specific Handler in the pipeline
+     * Param: Name of the handler
+     */
+    static NAN_METHOD(enableHandler);
+    /*
+     * Disables a specific Handler in the pipeline
+     * Param: Name of the handler
+     */
+    static NAN_METHOD(disableHandler);
 
     static Nan::Persistent<v8::Function> constructor;
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -713,6 +713,13 @@ Erizo.Room = function (spec) {
         }
     };
 
+    that.sendControlMessage = function(stream, type, action) {
+      if (stream && stream.getID()) {
+        var msg = {type: 'control', action: action};
+        sendSDPSocket('signaling_message', {streamId: stream.getID(), msg: msg});
+      }
+    };
+
     // It subscribe to a remote stream and draws it inside the HTML tag given by the ID='elementID'
     that.subscribe = function (stream, options, callback) {
 

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -7,7 +7,7 @@
 var Erizo = Erizo || {};
 Erizo.Stream = function (spec) {
     var that = Erizo.EventDispatcher(spec),
-        getFrame;
+        getFrame, controlHandler;
 
     that.stream = spec.stream;
     that.url = spec.url;
@@ -289,6 +289,24 @@ Erizo.Stream = function (spec) {
         var config = {muteStream : {audio : isMuted}};
         that.checkOptions(config, true);
         that.pc.updateSpec(config, callback);
+    };
+
+    controlHandler = function (handlers, publisherSide, enable) {
+      publisherSide = !(publisherSide !== true);
+      var handlers = (typeof handlers === 'string') ? [handlers] : handlers;
+      handlers = (handlers instanceof Array) ? handlers : [];
+
+      if (handlers.length > 0) {
+        that.room.sendControlMessage(that, 'control', {name: 'controlhandlers', enable: enable, publisherSide: publisherSide, handlers: handlers});
+      }
+    };
+
+    that.disableHandlers = function (handlers, publisherSide) {
+      controlHandler(handlers, publisherSide, false);
+    };
+
+    that.enableHandlers = function (handlers, publisherSide) {
+        controlHandler(handlers, publisherSide, true);
     };
 
     that.updateConfiguration = function (config, callback) {

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -213,9 +213,22 @@ exports.ErizoJSController = function (threadPool) {
         }
     };
 
+    var processControlMessage = function(publisher, subscriber, action) {
+      var publisherSide = subscriber === undefined || msg.publisherSide;
+      switch(action.name) {
+        case 'controlhandlers':
+          if (action.enable) {
+            publisher.enableHandlers(publisherSide ? undefined : subscriber.id, action.handlers);
+          } else {
+            publisher.disableHandlers(publisherSide ? undefined : subscriber.id, action.handlers);
+          }
+          break;
+      }
+    };
+
     that.processSignaling = function (streamId, peerId, msg) {
         log.info('message: Process Signaling message, ' +
-                 'streamId: ' + streamId + ', peerId: ' + peerId, msg);
+                 'streamId: ' + streamId + ', peerId: ' + peerId);
         if (publishers[streamId] !== undefined) {
             var publisher = publishers[streamId];
             if (publisher.hasSubscriber(peerId)) {
@@ -237,6 +250,8 @@ exports.ErizoJSController = function (threadPool) {
                             that.muteStream (msg.config.muteStream, peerId, streamId);
                         }
                     }
+                } else if (msg.type === 'control') {
+                  processControlMessage(publisher, subscriber, msg.action);
                 }
             } else {
                 if (msg.type === 'offer') {
@@ -266,6 +281,8 @@ exports.ErizoJSController = function (threadPool) {
                             that.muteStream (msg.config.muteStream, peerId, streamId);
                         }
                     }
+                } else if (msg.type === 'control') {
+                  processControlMessage(publisher, undefined, msg.action);
                 }
             }
 

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -115,6 +115,30 @@ class Source {
     subscriber.muteStream(this.muteVideo || muteVideo,
                           this.muteAudio || muteAudio);
   }
+
+  enableHandlers(id, handlers) {
+    var wrtc = this.wrtc;
+    if (id) {
+      wrtc = this.getSubscriber(id);
+    }
+    if (wrtc) {
+      for (var index in handlers) {
+        wrtc.enableHandler(handlers[index]);
+      }
+    }
+  }
+
+  disableHandlers(id, handlers) {
+    var wrtc = this.wrtc;
+    if (id) {
+      wrtc = this.getSubscriber(id);
+    }
+    if (wrtc) {
+      for (var index in handlers) {
+        wrtc.disableHandler(handlers[index]);
+      }
+    }
+  }
 }
 
 class Publisher extends Source {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -7,7 +7,7 @@ var logger = require('./../../common/logger').logger;
 var log = logger.getLogger('Publisher');
 
 function createWrtc(id, threadPool) {
-  return new addon.WebRtcConnection(threadPool, id,
+  var wrtc = new addon.WebRtcConnection(threadPool, id,
                                     GLOBAL.config.erizo.stunserver,
                                     GLOBAL.config.erizo.stunport,
                                     GLOBAL.config.erizo.minport,
@@ -18,6 +18,11 @@ function createWrtc(id, threadPool) {
                                     GLOBAL.config.erizo.turnport,
                                     GLOBAL.config.erizo.turnusername,
                                     GLOBAL.config.erizo.turnpass);
+  var disabledHandlers = GLOBAL.config.erizo['disabled_handlers'];
+  for (var index in disabledHandlers) {
+    wrtc.disableHandler(disabledHandlers[index]);
+  }
+  return wrtc;
 }
 
 class Source {

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -85,7 +85,7 @@ config.erizoController.interval_time_keepAlive = 1000; // default value: 1000
 
 // Roles to be used by services
 config.erizoController.roles =
-{"presenter": {"publish": true, "subscribe": true, "record": true},
+{"presenter": {"publish": true, "subscribe": true, "record": true, "controlhandlers": true},
     "viewer": {"subscribe": true},
     "viewerWithData": {"subscribe": true, "publish": {"audio": false, "video": false, "screen": false, "data": true}}}; // default value: {"presenter":{"publish": true, "subscribe":true, "record":true}, "viewer":{"subscribe":true}, "viewerWithData":{"subscribe":true, "publish":{"audio":false,"video":false,"screen":false,"data":true}}}
 

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -159,6 +159,8 @@ config.erizo.turnpass = '';
 config.erizo.minport = 0; // default value: 0
 config.erizo.maxport = 0; // default value: 0
 
+config.erizo['disabled_handlers'] = []; // there are no handlers disabled by default
+
 /***** END *****/
 // Following lines are always needed.
 var module = module || {};


### PR DESCRIPTION
With this PR we'll be able to disable handlers (and functionality) by default in Erizo. 

Each handler will now use a unique name to be identified and we can disable them with a line like this one in licode_config.js :
```js 
config.erizo['disabled_handlers'] = ['bwe', 'retransmissions'];
```