### PR TITLE
Added client-side API to access stats from Erizo

### DIFF
--- a/erizo/src/erizo/Stats.cpp
+++ b/erizo/src/erizo/Stats.cpp
@@ -25,6 +25,7 @@ namespace erizo {
   }
 
   uint32_t Stats::processRtpPacket(char* buf, int len) {
+    boost::recursive_mutex::scoped_lock lock(mapMutex_);
     RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
     if (chead->isRtcp())
       return 0;
@@ -34,7 +35,7 @@ namespace erizo {
     if (bitrate_bytes_map.find(ssrc) == bitrate_bytes_map.end()) {
       bitrate_bytes_map[ssrc] = 0;
     }
-    bitrate_bytes_map[ssrc]+=len;
+    bitrate_bytes_map[ssrc] += len;
     time_point nowms = clock::now();
     time_point start = bitrate_calculation_start_;
     duration delay = nowms - start;

--- a/erizo/src/erizo/Stats.cpp
+++ b/erizo/src/erizo/Stats.cpp
@@ -26,15 +26,29 @@ namespace erizo {
   }
 
   uint32_t Stats::processRtpPacket(char* buf, int len) {
-    rtpBytesReceived_+=len;
+    RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
+    if (chead->isRtcp())
+      return 0;
+
+    RtpHeader* head = reinterpret_cast<RtpHeader*>(buf);
+    uint32_t ssrc = head->getSSRC();
+    if (bitrate_bytes_map.find(ssrc) == bitrate_bytes_map.end()) {
+      bitrate_bytes_map[ssrc] = 0;
+    }
+    bitrate_bytes_map[ssrc]+=len;
     time_point nowms = clock::now();
     time_point start = bitrate_calculation_start_;
     duration delay = nowms - start;
+    uint32_t total_bitrate = 0;
     if (delay > kBitrateStatsPeriod) {
-      uint32_t receivedRtpBitrate_ = (8 * rtpBytesReceived_ * 1000) / ClockUtils::durationToMs(delay);  // in kbps
-      rtpBytesReceived_ = 0;
+      for (auto &bytes_pair : bitrate_bytes_map) {
+        uint32_t calculated_value = ((8 * bytes_pair.second * 1000) / ClockUtils::durationToMs(delay));  // in bps
+        setBitrateCalculated(calculated_value, bytes_pair.first);
+        total_bitrate += calculated_value;
+        bytes_pair.second = 0;
+      }
       bitrate_calculation_start_ = clock::now();
-      return receivedRtpBitrate_;  // in bps
+      return total_bitrate;
     }
     return 0;
   }
@@ -147,6 +161,10 @@ namespace erizo {
     }
     theString << "]";
     return theString.str();
+  }
+
+  void Stats::setEstimatedBandwidth(uint32_t bandwidth, uint32_t ssrc) {
+    setErizoEstimatedBandwidth(bandwidth, ssrc);
   }
 
   void Stats::sendStats() {

--- a/erizo/src/erizo/Stats.cpp
+++ b/erizo/src/erizo/Stats.cpp
@@ -17,7 +17,6 @@ namespace erizo {
   Stats::Stats() {
     ELOG_DEBUG("Constructor Stats");
     theListener_ = NULL;
-    rtpBytesReceived_ = 0;
     bitrate_calculation_start_ = clock::now();
   }
 

--- a/erizo/src/erizo/Stats.h
+++ b/erizo/src/erizo/Stats.h
@@ -62,7 +62,7 @@ class Stats {
   uint32_t getBitrateCalculated(unsigned int ssrc) {
     return(statsPacket_[ssrc]["bitrateCalculated"]);
   }
-  uint32_t setBitrateCalculated(uint32_t bitrate, uint32_t ssrc) {
+  void setBitrateCalculated(uint32_t bitrate, uint32_t ssrc) {
     statsPacket_[ssrc]["bitrateCalculated"] = bitrate;
   }
   uint32_t getPacketsLost(unsigned int ssrc) {

--- a/erizo/src/erizo/Stats.h
+++ b/erizo/src/erizo/Stats.h
@@ -29,6 +29,8 @@ class Stats {
 
   uint32_t processRtpPacket(char* buf, int len);
   void processRtcpPacket(char* buf, int length);
+  void setEstimatedBandwidth(uint32_t bandwidth, uint32_t ssrc);
+
   std::string getStats();
   // The video and audio SSRCs of the Client
   void setVideoSourceSSRC(unsigned int ssrc) {
@@ -42,12 +44,12 @@ class Stats {
   }
 
  private:
-  uint64_t rtpBytesReceived_, packetsReceived_;
   time_point bitrate_calculation_start_;
-
   typedef std::map<std::string, uint64_t> singleSSRCstatsMap_t;
   typedef std::map <uint32_t, singleSSRCstatsMap_t> fullStatsMap_t;
+
   fullStatsMap_t statsPacket_;
+  std::map<uint32_t, uint32_t> bitrate_bytes_map;
   boost::recursive_mutex mapMutex_;
   WebRtcConnectionStatsListener* theListener_;
   unsigned int videoSSRC_, audioSSRC_;
@@ -57,11 +59,12 @@ class Stats {
   uint32_t getPacketsReceived(unsigned int ssrc) {
     return(statsPacket_[ssrc]["packetsReceived"]);
   }
-
-  uint32_t getBitRateReceived(unsigned int ssrc) {
-    return(statsPacket_[ssrc]["bitRateReceived"]);
+  uint32_t getBitrateCalculated(unsigned int ssrc) {
+    return(statsPacket_[ssrc]["bitrateCalculated"]);
   }
-
+  uint32_t setBitrateCalculated(uint32_t bitrate, uint32_t ssrc) {
+    statsPacket_[ssrc]["bitrateCalculated"] = bitrate;
+  }
   uint32_t getPacketsLost(unsigned int ssrc) {
     return (statsPacket_[ssrc]["packetsLost"]);
   }
@@ -101,6 +104,13 @@ class Stats {
   }
   void setBandwidth(uint64_t count, unsigned int ssrc) {
     statsPacket_[ssrc]["bandwidth"] = count;
+  }
+
+  uint32_t getErizoEstimatedBandwidth(unsigned int ssrc) {
+    return statsPacket_[ssrc]["erizoBandwidth"];
+  }
+  void setErizoEstimatedBandwidth(uint32_t count, unsigned int ssrc) {
+    statsPacket_[ssrc]["erizoBandwidth"] = count;
   }
 
   void accountPLIMessage(unsigned int ssrc) {

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -664,6 +664,9 @@ WebRTCEvent WebRtcConnection::getCurrentState() {
 }
 
 std::string WebRtcConnection::getJSONStats() {
+  if (this->getVideoSourceSSRC()) {
+    thisStats_.setEstimatedBandwidth(bwe_handler_->getLastSendBitrate(), this->getVideoSourceSSRC());
+  }
   return thisStats_.getStats();
 }
 
@@ -710,6 +713,7 @@ void WebRtcConnection::write(std::shared_ptr<dataPacket> packet) {
   if (transport == nullptr) {
     return;
   }
+  thisStats_.processRtpPacket(packet->data, packet->length);
   this->extProcessor_.processRtpExtensions(packet);
   transport->write(packet->data, packet->length);
 }

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -184,7 +184,7 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   remb_packet_.setREMBFeedSSRC(connection_->getVideoSourceSSRC());
   int remb_length = (remb_packet_.getLength() + 1) * 4;
   if (temp_ctx_) {
-    ELOG_TRACE("BWE Estimation is %d", last_send_bitrate_);
+    ELOG_TRACE("BWE Estimation is %d", last_send_bitrate_.load());
     temp_ctx_->fireWrite(std::make_shared<dataPacket>(0,
       reinterpret_cast<char*>(&remb_packet_), remb_length, OTHER_PACKET));
   }

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -216,4 +216,8 @@ void BandwidthEstimationHandler::OnReceiveBitrateChanged(const std::vector<uint3
   last_send_bitrate_ = bitrate_;
   sendREMBPacket();
 }
+
+uint32_t BandwidthEstimationHandler::getLastSendBitrate() {
+  return last_send_bitrate_;
+}
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -47,6 +47,8 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
 
   void updateExtensionMaps(std::array<RTPExtensions, 10> video_map, std::array<RTPExtensions, 10> audio_map);
 
+  uint32_t getLastSendBitrate();
+
  private:
   void process();
   void sendREMBPacket();

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <vector>
+#include <atomic>
 
 #include "./logger.h"
 #include "pipeline/Handler.h"
@@ -71,7 +72,8 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   RtcpHeader remb_packet_;
   RtpHeaderExtensionMap ext_map_audio_, ext_map_video_;
   Context *temp_ctx_;
-  uint32_t bitrate_, last_send_bitrate_;
+  uint32_t bitrate_;
+  std::atomic<uint32_t> last_send_bitrate_;
   uint64_t last_remb_time_;
   bool running_;
 };

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -852,6 +852,22 @@ Erizo.Room = function (spec) {
         }
     };
 
+    that.getStreamStats = function (stream, callback) {
+        if (!that.socket) {
+            return 'Error getting stats - no socket';
+        }
+        if (!stream) {
+            return 'Error getting stats - no stream';
+        }
+        
+        sendMessageSocket('getStreamStats', stream.getID(), function (result) {
+            if (result) {
+                L.Logger.info('Got stats', result);
+                callback(result);
+            }
+        });
+    };
+
     //It searchs the streams that have "name" attribute with "value" value
     that.getStreamsByAttribute = function (name, value) {
         var streams = [], index, stream;

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -967,7 +967,26 @@ var listen = function () {
                 updateMyState();
             }
         });
+        
+        socket.on('getStreamStats', function (streamId, callback) {
+            log.debug('Getting stats for streamId ' + streamId);
+            if (socket.user === undefined || !socket.user.permissions[Permission.PUBLISH]) {
+                log.info('message: unauthorized getStreamStats request');
+                if (callback) callback(null, 'Unauthorized');
+                return;
+            }
+            if (socket.room.streams[streamId] === undefined) {
+                log.info('message: bad getStreamStats request');
+                return;
+            }
+            if (socket.room !== undefined){
+                socket.room.controller.getStreamStats(streamId, function (result) {
+                    callback(result);
+                });
+            }
+        });
     });
+
 };
 
 

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -970,7 +970,7 @@ var listen = function () {
         
         socket.on('getStreamStats', function (streamId, callback) {
             log.debug('Getting stats for streamId ' + streamId);
-            if (socket.user === undefined || !socket.user.permissions[Permission.PUBLISH]) {
+            if (socket.user === undefined || !socket.user.permissions[Permission.STATS]) {
                 log.info('message: unauthorized getStreamStats request');
                 if (callback) callback(null, 'Unauthorized');
                 return;

--- a/erizo_controller/erizoController/permission.js
+++ b/erizo_controller/erizoController/permission.js
@@ -10,6 +10,6 @@ permission.DATA = 'data';
 permission.AUDIO = 'audio';
 permission.VIDEO = 'video';
 permission.SCREEN = 'screen';
-
+permission.STATS = 'stats';
 
 module.exports = permission;

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -380,5 +380,18 @@ exports.RoomController = function (spec) {
         }
     };
 
+    that.getStreamStats = function (streamId, callback) {
+        if (publishers[streamId]) {
+            var args = [streamId]
+            var theId = getErizoQueue(streamId);
+            log.info('Get stats for publisher ', streamId, 'theId', theId);
+            amqper.callRpc(getErizoQueue(streamId), 'getStreamStats', args, {callback: function(data) {
+                log.info('Got data', data);
+                callback(data);
+            }});
+            return;
+        }
+    };
+
     return that;
 };

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -386,7 +386,6 @@ exports.RoomController = function (spec) {
             var theId = getErizoQueue(streamId);
             log.info('Get stats for publisher ', streamId, 'theId', theId);
             amqper.callRpc(getErizoQueue(streamId), 'getStreamStats', args, {callback: function(data) {
-                log.info('Got data', data);
                 callback(data);
             }});
             return;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -510,24 +510,11 @@ exports.ErizoJSController = function (threadPool) {
                 var unfilteredStats = JSON.parse(publisher.subscribers[sub].getStats());
                 for (var channel in unfilteredStats) {
                     var ssrc = unfilteredStats[channel].sourceSsrc;
-                    var isReceivedBitrate = false;
                     if (ssrc === undefined) {
                         ssrc = unfilteredStats[channel].ssrc;
-                        isReceivedBitrate = true;
                     }
-                    if (!stats[sub][ssrc]) {
-                        stats[sub][ssrc] = {};
-                    }
-                    if (isReceivedBitrate) {
-                        stats[sub][ssrc].bitrateCalculated = unfilteredStats[channel].bitrateCalculated;
-                    } else {
-                        stats[sub][ssrc].plis = unfilteredStats[channel].PLI;
-                        stats[sub][ssrc].nacks = unfilteredStats[channel].NACK;
-                        stats[sub][ssrc].packetsLost = unfilteredStats[channel].packetsLost;
-                        stats[sub][ssrc].jitter = unfilteredStats[channel].jitter;
-                        stats[sub][ssrc].ratioLost = unfilteredStats[channel].fractionLost;
-                        stats[sub][ssrc].bandwidth = unfilteredStats[channel].bandwidth;
-                    }
+                    stats[sub][ssrc] = stats[sub][ssrc] || {};
+                    stats[sub][ssrc] = Object.assign(stats[sub][ssrc],  unfilteredStats[channel]);
                 }
                 stats[sub].metadata = publisher.subscribers[sub].metadata;
             }

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -485,5 +485,22 @@ exports.ErizoJSController = function (threadPool) {
         }
     };
 
+    that.getStreamStats = function (to, callback) {
+        var stats = {};
+        var publisher;
+        if (to && publishers[to]) {
+            publisher = publishers[to];
+            stats.publisher = JSON.parse(publisher.wrtc.getStats());
+            stats.publisher.metadata = publisher.wrtc.metadata;
+            var subscriber;
+            for (var sub in publisher.subscribers) {
+                stats[sub] = JSON.parse(publisher.subscribers[sub].getStats());
+                stats[sub].metadata = publisher.subscribers[sub].metadata;
+            }
+        }
+        log.info('GEtStreamStats', stats);
+        callback('callback', stats);
+    };
+
     return that;
 };

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -85,7 +85,7 @@ config.erizoController.interval_time_keepAlive = 1000; // default value: 1000
 
 // Roles to be used by services
 config.erizoController.roles =
-{"presenter": {"publish": true, "subscribe": true, "record": true},
+{"presenter": {"publish": true, "subscribe": true, "record": true, "stats": true},
     "viewer": {"subscribe": true},
     "viewerWithData": {"subscribe": true, "publish": {"audio": false, "video": false, "screen": false, "data": true}}}; // default value: {"presenter":{"publish": true, "subscribe":true, "record":true}, "viewer":{"subscribe":true}, "viewerWithData":{"subscribe":true, "publish":{"audio":false,"video":false,"screen":false,"data":true}}}
 


### PR DESCRIPTION
ErizoClient can be used to access real-time stats gathered directly by Erizo. They contain mostly from RTCP packets from the clients but also a couple of Erizo-calculated values: actual bitrates and the output from the Erizo bitrate estimator.

The API may change but for now they are accessed with:
`room.getStreamStats(streamID, callback)` where the callback takes one parameter, the actual stats data in JSON format.

Also, this PR introduces a new _permission_:`STATS` that can be used to limit which roles can access the stats.