### PR TITLE
Adding parameters to create offer when publishing

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -132,11 +132,11 @@ exports.ErizoJSController = function (threadPool) {
                     break;
             }
         });
-        if (options.createOffer === true) {
+        if (options.createOffer) {
             log.debug('message: create offer requested, id:', wrtc.wrtcId);
-            var audioEnabled = true;
-            var videoEnabled = true;
-            var bundle = true;
+            var audioEnabled = options.createOffer.audio;
+            var videoEnabled = options.createOffer.video;
+            var bundle = options.createOffer.bundle;
             wrtc.createOffer(audioEnabled, videoEnabled, bundle);
         }
         callback('callback', {type: 'initializing'});

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -200,7 +200,7 @@ describe('Erizo JS Controller', function() {
 
     it('should succeed sending offer event', function() {
       mocks.WebRtcConnection.init.returns(1).callsArgWith(0, 103, '');  // CONN_GATHERED
-      controller.addPublisher(kArbitraryId, {createOffer: true}, callback);
+      controller.addPublisher(kArbitraryId, {createOffer: {audio: true, video: true, bundle: true}}, callback);
 
       expect(callback.callCount).to.equal(2);
       expect(callback.args[1]).to.deep.equal(['callback', {type: 'initializing'}]);


### PR DESCRIPTION
This PR makes create offer parameters (audio, video and bundle) configurable when publishing a stream. 

The Erizo Client API has an small change: 

- Before
`room.publish(stream, { createOffer: true });`

- Now
`room.publish(stream, { createOffer: {audio: true, video: true, bundle: true} );`

