### PR TITLE
SlideshowMode can be configured at different periods now

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -441,7 +441,7 @@ exports.ErizoJSController = function (threadPool) {
     /*
      * Enables/Disables slideshow mode for a subscriber
      */
-    that.setSlideShow = function (slideShowMode, from, to, period) {
+    that.setSlideShow = function (slideShowMode, from, to) {
         var wrtcPub;
         var publisher = publishers[to];
         var theWrtc = publisher.getSubscriber(from);


### PR DESCRIPTION
By passing a period in milliseconds instead of `true` to the slideShowMode option from erizoClient, you can now adjust the slideShow frame rate.