### PR TITLE
Added extension mappings to media config file

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 
+#include <algorithm>
 #include <sstream>
 #include <cstdlib>
 #include <cstring>
@@ -111,6 +112,17 @@ namespace erizo {
 
   void SdpInfo::addCrypto(const CryptoInfo& info) {
     cryptoVector_.push_back(info);
+  }
+
+  void SdpInfo::updateSupportedExtensionMap(const std::vector<ExtMap> &ext_map) {
+    supported_ext_map_ = ext_map;
+  }
+
+  bool SdpInfo::isValidExtension(std::string uri) {
+    auto value = std::find_if(supported_ext_map_.begin(), supported_ext_map_.end(), [uri](const ExtMap &extension) {
+      return extension.uri == uri;
+    });
+    return value != supported_ext_map_.end();
   }
 
   void SdpInfo::setCredentials(const std::string& username, const std::string& password, MediaType media) {
@@ -236,7 +248,7 @@ namespace erizo {
 
       ELOG_DEBUG("Writing Extmap for AUDIO %lu", extMapVector.size());
       for (uint8_t i = 0; i < extMapVector.size(); i++) {
-        if (extMapVector[i].mediaType == AUDIO_TYPE) {
+        if (extMapVector[i].mediaType == AUDIO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
           sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
         }
       }
@@ -330,7 +342,7 @@ namespace erizo {
 
       ELOG_DEBUG("Writing Extmap for VIDEO %lu", extMapVector.size());
       for (uint8_t i = 0; i < extMapVector.size(); i++) {
-        if (extMapVector[i].mediaType == VIDEO_TYPE) {
+        if (extMapVector[i].mediaType == VIDEO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
           sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
         }
       }

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -221,6 +221,9 @@ class SdpInfo {
    */
   void setOfferSdp(const SdpInfo& offerSdp);
 
+  void updateSupportedExtensionMap(const std::vector<ExtMap> &ext_map);
+  bool isValidExtension(std::string uri);
+
   /**
    * The audio and video SSRCs for this particular SDP.
    */
@@ -274,6 +277,7 @@ class SdpInfo {
 
   std::vector<BundleTag> bundleTags;
   std::vector<ExtMap> extMapVector;
+
   /*
    * MLines for video and audio
    */
@@ -293,6 +297,7 @@ class SdpInfo {
   std::string iceVideoUsername_, iceAudioUsername_;
   std::string iceVideoPassword_, iceAudioPassword_;
   std::map<unsigned int, RtpMap> payload_parsed_map_;
+  std::vector<ExtMap> supported_ext_map_;
 };
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_SDPINFO_H_

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -72,7 +72,8 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
    * Constructs an empty WebRTCConnection without any configuration.
    */
   WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id, const IceConfig& iceConfig,
-      const std::vector<RtpMap> rtp_mappings, WebRtcConnectionEventListener* listener);
+      const std::vector<RtpMap> rtp_mappings, const std::vector<erizo::ExtMap> ext_mappings,
+      WebRtcConnectionEventListener* listener);
   /**
    * Destructor.
    */

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
@@ -4,13 +4,15 @@
 #include "rtp/RtpExtensionProcessor.h"
 #include <map>
 #include <string>
+#include <vector>
 
 #include "lib/Clock.h"
 
 namespace erizo {
 DEFINE_LOGGER(RtpExtensionProcessor, "rtp.RtpExtensionProcessor");
 
-RtpExtensionProcessor::RtpExtensionProcessor() {
+RtpExtensionProcessor::RtpExtensionProcessor(const std::vector<erizo::ExtMap> ext_mappings) :
+    ext_mappings_{ext_mappings} {
   translationMap_["urn:ietf:params:rtp-hdrext:ssrc-audio-level"] = SSRC_AUDIO_LEVEL;
   translationMap_["http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"] = ABS_SEND_TIME;
   translationMap_["urn:ietf:params:rtp-hdrext:toffset"] = TOFFSET;
@@ -31,19 +33,17 @@ void RtpExtensionProcessor::setSdpInfo(const SdpInfo& theInfo) {
     std::map<std::string, uint8_t>::iterator it;
     switch (theMap.mediaType) {
       case VIDEO_TYPE:
-        it = translationMap_.find(theMap.uri);
-        if (it != translationMap_.end()) {
+        if (isValidExtension(theMap.uri)) {
           ELOG_DEBUG("Adding RTP Extension for video %s, value %u", theMap.uri.c_str(), theMap.value);
-          ext_map_video_[theMap.value] = RTPExtensions((*it).second);
+          ext_map_video_[theMap.value] = RTPExtensions((*translationMap_.find(theMap.uri)).second);
         } else {
           ELOG_WARN("Unsupported extension %s", theMap.uri.c_str());
         }
         break;
       case AUDIO_TYPE:
-        it = translationMap_.find(theMap.uri);
-        if (it != translationMap_.end()) {
+        if (isValidExtension(theMap.uri)) {
           ELOG_DEBUG("Adding RTP Extension for Audio %s, value %u", theMap.uri.c_str(), theMap.value);
-          ext_map_audio_[theMap.value] = RTPExtensions((*it).second);
+          ext_map_audio_[theMap.value] = RTPExtensions((*translationMap_.find(theMap.uri)).second);
         } else {
           ELOG_WARN("Unsupported extension %s", theMap.uri.c_str());
         }
@@ -53,6 +53,13 @@ void RtpExtensionProcessor::setSdpInfo(const SdpInfo& theInfo) {
         break;
     }
   }
+}
+
+bool RtpExtensionProcessor::isValidExtension(std::string uri) {
+  auto value = std::find_if(ext_mappings_.begin(), ext_mappings_.end(), [uri](const ExtMap &extension) {
+    return uri == extension.uri;
+  });
+  return value != ext_mappings_.end() && translationMap_.find(uri) != translationMap_.end();
 }
 
 uint32_t RtpExtensionProcessor::processRtpExtensions(std::shared_ptr<dataPacket> p) {

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.h
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.h
@@ -26,7 +26,7 @@ class RtpExtensionProcessor{
   DECLARE_LOGGER();
 
  public:
-  RtpExtensionProcessor();
+  explicit RtpExtensionProcessor(const std::vector<erizo::ExtMap> ext_mappings);
   virtual ~RtpExtensionProcessor();
 
   void setSdpInfo(const SdpInfo& theInfo);
@@ -38,8 +38,13 @@ class RtpExtensionProcessor{
   std::array<RTPExtensions, 10> getAudioExtensionMap() {
     return ext_map_audio_;
   }
+  std::vector<ExtMap> getSupportedExtensionMap() {
+    return ext_mappings_;
+  }
+  bool isValidExtension(std::string uri);
 
  private:
+  std::vector<ExtMap> ext_mappings_;
   std::array<RTPExtensions, 10> ext_map_video_, ext_map_audio_;
   std::map<std::string, uint8_t> translationMap_;
   uint32_t processAbsSendTime(char* buf);

--- a/erizo/src/test/rtp/RtpExtensionProcessorTest.cpp
+++ b/erizo/src/test/rtp/RtpExtensionProcessorTest.cpp
@@ -1,0 +1,49 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/RtpExtensionProcessor.h>
+
+#include <atomic>
+#include <chrono>  // NOLINT
+#include <string>
+#include <vector>
+#include <thread>  // NOLINT
+#include <condition_variable>  // NOLINT
+
+using testing::Eq;
+using testing::Not;
+
+class RtpExtensionProcessorTest : public ::testing::Test {
+ public:
+  virtual void SetUp() {
+    ext_mappings.push_back({1, "urn:ietf:params:rtp-hdrext:ssrc-audio-level"});
+  }
+  virtual void TearDown() {
+  }
+
+  std::vector<erizo::ExtMap> ext_mappings;
+};
+
+TEST_F(RtpExtensionProcessorTest, extensionShouldBeValidWhenItIsPassed) {
+  erizo::RtpExtensionProcessor processor(ext_mappings);
+
+  bool is_valid = processor.isValidExtension("urn:ietf:params:rtp-hdrext:ssrc-audio-level");
+
+  EXPECT_THAT(is_valid, Eq(true));
+}
+
+TEST_F(RtpExtensionProcessorTest, extensionShouldBeInvalidWhenItIsNotPassed) {
+  erizo::RtpExtensionProcessor processor(ext_mappings);
+
+  bool is_valid = processor.isValidExtension("http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time");
+
+  EXPECT_THAT(is_valid, Eq(false));
+}
+
+TEST_F(RtpExtensionProcessorTest, extensionShouldBeInvalidWhenWeDoNotKnowIt) {
+  erizo::RtpExtensionProcessor processor(ext_mappings);
+
+  bool is_valid = processor.isValidExtension("unknown");
+
+  EXPECT_THAT(is_valid, Eq(false));
+}

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -44,7 +44,7 @@ class MockWebRtcConnection: public WebRtcConnection {
  public:
   MockWebRtcConnection(std::shared_ptr<Worker> worker, const IceConfig &ice_config,
                        const std::vector<RtpMap> rtp_mappings) :
-    WebRtcConnection(worker, "", ice_config, rtp_mappings, nullptr) {}
+    WebRtcConnection(worker, "", ice_config, rtp_mappings, std::vector<erizo::ExtMap>(), nullptr) {}
 
   virtual ~MockWebRtcConnection() {
   }

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -132,6 +132,15 @@ NAN_METHOD(WebRtcConnection::New) {
       }
     }
 
+    std::vector<erizo::ExtMap> ext_mappings;
+    int16_t value = 0;
+    if (media_config.find("extMappings") != media_config.end()) {
+      json ext_map_json = media_config["extMappings"];
+      for (json::iterator ext_map_it = ext_map_json.begin(); ext_map_it != ext_map_json.end(); ++ext_map_it) {
+        ext_mappings.push_back({value++, *ext_map_it});
+      }
+    }
+
     erizo::IceConfig iceConfig;
     if (info.Length() == 13) {
       v8::String::Utf8Value param2(Nan::To<v8::String>(info[8]).ToLocalChecked());
@@ -161,7 +170,7 @@ NAN_METHOD(WebRtcConnection::New) {
     std::shared_ptr<erizo::Worker> worker = thread_pool->me->getLessUsedWorker();
 
     WebRtcConnection* obj = new WebRtcConnection();
-    obj->me = std::make_shared<erizo::WebRtcConnection>(worker, wrtcId, iceConfig, rtp_mappings, obj);
+    obj->me = std::make_shared<erizo::WebRtcConnection>(worker, wrtcId, iceConfig, rtp_mappings, ext_mappings, obj);
     obj->msink = obj->me.get();
     uv_async_init(uv_default_loop(), &obj->async_, &WebRtcConnection::eventsCallback);
     uv_async_init(uv_default_loop(), &obj->asyncStats_, &WebRtcConnection::statsCallback);

--- a/scripts/rtp_media_config_default.js
+++ b/scripts/rtp_media_config_default.js
@@ -1,5 +1,14 @@
 var mediaConfig = {};
 
+mediaConfig.extMappings = [
+  "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+  "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+  "urn:ietf:params:rtp-hdrext:toffset",
+  "urn:3gpp:video-orientation",
+  // "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+  "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"
+];
+
 mediaConfig.rtpMappings = {};
 
 mediaConfig.rtpMappings.vp8 = {


### PR DESCRIPTION
With this PR we need to provide a list of supported extensions via rtp_media_config.js.

It will disable transport-cc by default to keep using REMB and abs-send-time in Chrome 55, which is a bug we found today.