### PR TITLE
Add/frame rate constraints

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -140,7 +140,7 @@ Erizo.GetUserMedia = function (config, callback, error) {
             L.Logger.error('Video/audio streams not supported in erizofc yet');
         } else {
             if (config.video && Erizo.getBrowser() === 'mozilla') {
-                var ffConfig = {video:{}, audio: config.audio}
+                var ffConfig = {video:{}, audio: config.audio, screen: config.screen}
                 if (config.video.mandatory !== undefined) {
                     var videoCfg = config.video.mandatory;
                     ffConfig.video.width = {min: videoCfg.minWidth, max: videoCfg.maxWidth};

--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -140,16 +140,18 @@ Erizo.GetUserMedia = function (config, callback, error) {
             L.Logger.error('Video/audio streams not supported in erizofc yet');
         } else {
             if (config.video && Erizo.getBrowser() === 'mozilla') {
+                var ffConfig = {video:{}, audio: config.audio}
                 if (config.video.mandatory !== undefined) {
                     var videoCfg = config.video.mandatory;
-                    config.video = {
-                        width: {min: videoCfg.minWidth, max: videoCfg.maxWidth},
-                        height: {min: videoCfg.minHeight, max: videoCfg.maxHeight},
-                        frameRate: {min: videoCfg.minFrameRate, max: videoCfg.maxFrameRate}
-                    };
+                    ffConfig.video.width = {min: videoCfg.minWidth, max: videoCfg.maxWidth};
+                    ffConfig.video.height = {min: videoCfg.minHeight, max: videoCfg.maxHeight};
+
+                }
+                if (config.video.optional !== undefined) {
+                    ffConfig.video.frameRate =  config.video.optional[1].maxFrameRate
                 }
                 if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-                    promise = navigator.mediaDevices.getUserMedia(config).then(callback);
+                    promise = navigator.mediaDevices.getUserMedia(ffConfig).then(callback);
                     // Google compressor complains about a func called catch
                     promise['catch'](error);
                     return;

--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -144,7 +144,8 @@ Erizo.GetUserMedia = function (config, callback, error) {
                     var videoCfg = config.video.mandatory;
                     config.video = {
                         width: {min: videoCfg.minWidth, max: videoCfg.maxWidth},
-                        height: {min: videoCfg.minHeight, max: videoCfg.maxHeight}
+                        height: {min: videoCfg.minHeight, max: videoCfg.maxHeight},
+                        frameRate: {min: videoCfg.minFrameRate, max: videoCfg.maxFrameRate}
                     };
                 }
                 if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -19,6 +19,7 @@ Erizo.Stream = function (spec) {
     that.audio = spec.audio;
     that.screen = spec.screen;
     that.videoSize = spec.videoSize;
+    that.videoFrameRate = spec.videoFrameRate;
     that.extensionId = spec.extensionId;
 
     if (that.videoSize !== undefined &&
@@ -91,12 +92,18 @@ Erizo.Stream = function (spec) {
         if ((spec.audio || spec.video || spec.screen) && spec.url === undefined) {
           L.Logger.info('Requested access to local media');
           var videoOpt = spec.video;
-          if ((videoOpt === true || spec.screen === true) &&
-              that.videoSize !== undefined) {
-            videoOpt = {mandatory: {minWidth: that.videoSize[0],
-                                    minHeight: that.videoSize[1],
-                                    maxWidth: that.videoSize[2],
-                                    maxHeight: that.videoSize[3]}};
+          if (videoOpt === true || spec.screen === true) {
+              videoOpt = {mandatory: {}}
+              if (that.videoSize !== undefined) {
+                  videoOpt.mandatory.minWidth = that.videoSize[0];
+                  videoOpt.mandatory.minHeight = that.videoSize[1];
+                  videoOpt.mandatory.maxWidth = that.videoSize[2];
+                  videoOpt.mandatory.maxHeight = that.videoSize[3];
+              }
+              if (that.videoFrameRate !== undefined) {
+                  videoOpt.mandatory.minFrameRate = that.videoFrameRate[0];
+                  videoOpt.mandatory.maxFrameRate = that.videoFrameRate[1];
+              }
           } else if (spec.screen === true && videoOpt === undefined) {
             videoOpt = true;
           }

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -93,17 +93,21 @@ Erizo.Stream = function (spec) {
           L.Logger.info('Requested access to local media');
           var videoOpt = spec.video;
           if (videoOpt === true || spec.screen === true) {
-              videoOpt = {mandatory: {}}
+              videoOpt = {}
               if (that.videoSize !== undefined) {
+                  videoOpt.mandatory = {};
                   videoOpt.mandatory.minWidth = that.videoSize[0];
                   videoOpt.mandatory.minHeight = that.videoSize[1];
                   videoOpt.mandatory.maxWidth = that.videoSize[2];
                   videoOpt.mandatory.maxHeight = that.videoSize[3];
               }
+              
               if (that.videoFrameRate !== undefined) {
-                  videoOpt.mandatory.minFrameRate = that.videoFrameRate[0];
-                  videoOpt.mandatory.maxFrameRate = that.videoFrameRate[1];
+                  videoOpt.optional = []
+                  videoOpt.optional.push({minFrameRate: that.videoFrameRate[0]});
+                  videoOpt.optional.push({maxFrameRate: that.videoFrameRate[1]});
               }
+              
           } else if (spec.screen === true && videoOpt === undefined) {
             videoOpt = true;
           }

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -55,7 +55,8 @@ window.onload = function () {
                 video: true,
                 data: true,
                 screen: screen,
-                videoSize: [640, 480, 640, 480]};
+                videoSize: [640, 480, 640, 480],
+                videoFrameRate: [10, 20]};
   // If we want screen sharing we have to put our Chrome extension id.
   // The default one only works in our Lynckia test servers.
   // If we are not using chrome, the creation of the stream will fail regardless.


### PR DESCRIPTION
Video frameRate for a local stream can now be configured in the constructor `Erizo.Stream(config)` by setting `config.videoFramerate = [minFrameRate, maxFrameRate]`. 
Note this are _optional_ or _ideal_ constraints meaning getUserMedia will ignore the constraint if it cannot be complied