### PR TITLE
Add/drop bye packets

### DIFF
--- a/erizo/src/erizo/rtp/RtcpForwarder.cpp
+++ b/erizo/src/erizo/rtp/RtcpForwarder.cpp
@@ -85,7 +85,8 @@ int RtcpForwarder::analyzeFeedback(char *buf, int len) {
           ELOG_DEBUG("SDES");
           break;
         case RTCP_BYE:
-          ELOG_DEBUG("BYE");
+          ELOG_DEBUG("Dropping BYE packet");
+          return 0;
           break;
         case RTCP_Receiver_PT:
           if (chead->getSourceSSRC() == rtcpSource_->getVideoSourceSSRC()) {

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -133,7 +133,7 @@ NAN_METHOD(WebRtcConnection::New) {
     }
 
     std::vector<erizo::ExtMap> ext_mappings;
-    int16_t value = 0;
+    unsigned int value = 0;
     if (media_config.find("extMappings") != media_config.end()) {
       json ext_map_json = media_config["extMappings"];
       for (json::iterator ext_map_it = ext_map_json.begin(); ext_map_it != ext_map_json.end(); ++ext_map_it) {


### PR DESCRIPTION
Drop BYE packets in RtcpForwarder because we usually don't want to say bye at that point 