### PR TITLE
Update handlers interface to avoid mutex and external lists

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -16,6 +16,12 @@
 #include "rtp/RtpVP8Parser.h"
 #include "rtp/RtcpAggregator.h"
 #include "rtp/RtcpForwarder.h"
+#include "rtp/RtpSlideShowHandler.h"
+#include "rtp/RtpVP8SlideShowHandler.h"
+#include "rtp/RtpAudioMuteHandler.h"
+#include "rtp/BandwidthEstimationHandler.h"
+#include "rtp/FecReceiverHandler.h"
+#include "rtp/RtcpProcessorHandler.h"
 #include "rtp/RtpRetransmissionHandler.h"
 #include "rtp/StatsHandler.h"
 
@@ -28,7 +34,7 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
     connection_id_{connection_id}, remoteSdp_{SdpInfo(rtp_mappings)}, localSdp_{SdpInfo(rtp_mappings)},
     audioEnabled_{false}, videoEnabled_{false}, bundle_{false}, connEventListener_{listener},
     iceConfig_{iceConfig}, rtp_mappings_{rtp_mappings}, extProcessor_{ext_mappings},
-    pipeline_{Pipeline::create()}, worker_{worker} {
+    pipeline_{Pipeline::create()}, worker_{worker}, audio_muted_{false} {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort);
   setVideoSinkSSRC(55543);
@@ -42,29 +48,18 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
 
   rtcp_processor_ = std::make_shared<RtcpForwarder>(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this));
 
-  slideshow_handler_ = std::make_shared<RtpVP8SlideShowHandler>(this);
-  audio_mute_handler_ = std::make_shared<RtpAudioMuteHandler>(this);
-  bwe_handler_ = std::make_shared<BandwidthEstimationHandler>(this, worker_);
-  fec_handler_ = std::make_shared<FecReceiverHandler>(this);
-  rtcp_processor_handler_ = std::make_shared<RtcpProcessorHandler>(this, rtcp_processor_);
-
   // TODO(pedro): consider creating the pipeline on setRemoteSdp or createOffer
   pipeline_->addFront(PacketReader(this));
-  pipeline_->addFront(rtcp_processor_handler_);
+  pipeline_->addFront(RtcpProcessorHandler(this, rtcp_processor_));
   pipeline_->addFront(IncomingStatsHandler(this));
-  pipeline_->addFront(fec_handler_);
-  pipeline_->addFront(audio_mute_handler_);
-  pipeline_->addFront(slideshow_handler_);
-  pipeline_->addFront(bwe_handler_);
+  pipeline_->addFront(FecReceiverHandler(this));
+  pipeline_->addFront(RtpAudioMuteHandler(this));
+  pipeline_->addFront(RtpVP8SlideShowHandler(this));
+  pipeline_->addFront(std::make_shared<BandwidthEstimationHandler>(this, worker_));
   pipeline_->addFront(RtpRetransmissionHandler(this));
   pipeline_->addFront(OutgoingStatsHandler(this));
   pipeline_->addFront(PacketWriter(this));
   pipeline_->finalize();
-
-  // TODO(javierc): we need to improve this mechanism to enable/disable handlers using the same pipeline
-  handlers_.push_back(audio_mute_handler_);
-  handlers_.push_back(slideshow_handler_);
-  handlers_.push_back(bwe_handler_);
 
   trickleEnabled_ = iceConfig_.shouldTrickle;
 
@@ -156,11 +151,6 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
 
   localSdp_.updateSupportedExtensionMap(extProcessor_.getSupportedExtensionMap());
 
-  bwe_handler_->updateExtensionMaps(extProcessor_.getVideoExtensionMap(), extProcessor_.getAudioExtensionMap());
-  if (!remoteSdp_.supportPayloadType(RED_90000_PT) || slide_show_mode_) {
-    fec_handler_->enable();
-  }
-
   localSdp_.videoSsrc = this->getVideoSinkSSRC();
   localSdp_.audioSsrc = this->getAudioSinkSSRC();
 
@@ -238,6 +228,8 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
     ELOG_DEBUG("%s message: Setting remote BW, maxVideoBW: %u", toLog(), remoteSdp_.videoBandwidth);
     this->rtcp_processor_->setMaxVideoBW(remoteSdp_.videoBandwidth*1000);
   }
+
+  notifyUpdateToHandlers();
 
   return true;
 }
@@ -605,18 +597,14 @@ void WebRtcConnection::setSlideShowMode(bool state) {
   }
   stats_.setSlideShowMode(state, this->getVideoSinkSSRC());
   slide_show_mode_ = state;
-  slideshow_handler_->setSlideShowMode(state);
-  if (!remoteSdp_.supportPayloadType(RED_90000_PT) || state) {
-    fec_handler_->enable();
-  } else {
-    fec_handler_->disable();
-  }
+  notifyUpdateToHandlers();
 }
 
 void WebRtcConnection::muteStream(bool mute_video, bool mute_audio) {
   ELOG_DEBUG("%s message: muteStream, mute_video: %u, mute_audio: %u", toLog(), mute_video, mute_audio);
   stats_.setMute(mute_audio, this->getAudioSinkSSRC());
-  audio_mute_handler_->muteAudio(mute_audio);
+  audio_muted_ = mute_audio;
+  notifyUpdateToHandlers();
 }
 
 void WebRtcConnection::setFeedbackReports(bool will_send_fb, uint32_t target_bitrate) {
@@ -640,9 +628,6 @@ WebRTCEvent WebRtcConnection::getCurrentState() {
 }
 
 std::string WebRtcConnection::getJSONStats() {
-  if (this->getVideoSourceSSRC()) {
-    stats_.setEstimatedBandwidth(bwe_handler_->getLastSendBitrate(), this->getVideoSourceSSRC());
-  }
   std::string requestedStats = stats_.getStats();
   ELOG_DEBUG("%s message: Stats, stats: %s", toLog(), requestedStats.c_str());
   return requestedStats;
@@ -695,32 +680,21 @@ void WebRtcConnection::write(std::shared_ptr<dataPacket> packet) {
   transport->write(packet->data, packet->length);
 }
 
-std::shared_ptr<Handler> WebRtcConnection::getHandler(const std::string &name) {
-  std::shared_ptr<Handler> handler;
-  auto it = std::find_if(handlers_.begin(), handlers_.end(), [&name](std::shared_ptr<Handler> handler) {
-    return handler->getName() == name;
-  });
-  if (it != handlers_.end()) {
-    handler = *it;
-  }
-  return handler;
-}
-
 void WebRtcConnection::enableHandler(const std::string &name) {
-  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn){
-    auto handler = conn->getHandler(name);
-    if (handler.get()) {
-      handler->enable();
-    }
+  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn) {
+    conn->pipeline_->enable(name);
   });
 }
 
 void WebRtcConnection::disableHandler(const std::string &name) {
-  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn){
-    auto handler = conn->getHandler(name);
-    if (handler.get()) {
-      handler->disable();
-    }
+  asyncTask([name] (std::shared_ptr<WebRtcConnection> conn) {
+    conn->pipeline_->disable(name);
+  });
+}
+
+void WebRtcConnection::notifyUpdateToHandlers() {
+  asyncTask([] (std::shared_ptr<WebRtcConnection> conn) {
+    conn->pipeline_->notifyUpdate();
   });
 }
 

--- a/erizo/src/erizo/pipeline/Handler.h
+++ b/erizo/src/erizo/pipeline/Handler.h
@@ -66,6 +66,8 @@ class Handler : public HandlerBase<HandlerContext> {
   virtual void close(Context* ctx) {
     return ctx->fireClose();
   }
+
+  virtual void notifyUpdate() = 0;
 };
 
 class InboundHandler : public HandlerBase<InboundHandlerContext> {
@@ -90,6 +92,8 @@ class InboundHandler : public HandlerBase<InboundHandlerContext> {
   virtual void transportInactive(Context* ctx) {
     ctx->fireTransportInactive();
   }
+
+  virtual void notifyUpdate() = 0;
 };
 
 class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
@@ -108,6 +112,8 @@ class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
   virtual void close(Context* ctx) {
     return ctx->fireClose();
   }
+
+  virtual void notifyUpdate() = 0;
 };
 
 class HandlerAdapter : public Handler {
@@ -130,6 +136,9 @@ class HandlerAdapter : public Handler {
 
   void write(Context* ctx, std::shared_ptr<dataPacket> packet) override {
     return ctx->fireWrite(packet);
+  }
+
+  void notifyUpdate() override {
   }
 };
 }  // namespace erizo

--- a/erizo/src/erizo/pipeline/HandlerContext-inl.h
+++ b/erizo/src/erizo/pipeline/HandlerContext-inl.h
@@ -21,6 +21,11 @@ class PipelineContext {
   virtual void attachPipeline() = 0;
   virtual void detachPipeline() = 0;
 
+  virtual void notifyUpdate() = 0;
+  virtual std::string getName() = 0;
+  virtual void enable() = 0;
+  virtual void disable() = 0;
+
   template <class H, class HandlerContext>
   void attachContext(H* handler, HandlerContext* ctx) {
     if (++handler->attachCount_ == 1) {
@@ -67,6 +72,22 @@ class ContextImplBase : public PipelineContext {
     pipelineWeak_ = pipeline;
     pipelineRaw_ = pipeline.lock().get();
     handler_ = std::move(handler);
+  }
+
+  void notifyUpdate() override {
+    handler_->notifyUpdate();
+  }
+
+  std::string getName() override {
+    return handler_->getName();
+  }
+
+  void enable() override {
+    handler_->enable();
+  }
+
+  void disable() override {
+    handler_->disable();
   }
 
   // PipelineContext overrides

--- a/erizo/src/erizo/pipeline/Pipeline.cpp
+++ b/erizo/src/erizo/pipeline/Pipeline.cpp
@@ -11,6 +11,7 @@
 #include <pipeline/Pipeline.h>
 
 #include <cassert>
+#include <string>
 
 namespace erizo {
 
@@ -124,6 +125,28 @@ void Pipeline::finalize() {
 
   for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
     (*it)->attachPipeline();
+  }
+}
+
+void Pipeline::notifyUpdate() {
+  for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
+    (*it)->notifyUpdate();
+  }
+}
+
+void Pipeline::enable(std::string name) {
+  for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
+    if ((*it)->getName() == name) {
+      (*it)->enable();
+    }
+  }
+}
+
+void Pipeline::disable(std::string name) {
+  for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
+    if ((*it)->getName() == name) {
+      (*it)->disable();
+    }
   }
 }
 

--- a/erizo/src/erizo/pipeline/Pipeline.h
+++ b/erizo/src/erizo/pipeline/Pipeline.h
@@ -10,6 +10,7 @@
 #ifndef ERIZO_SRC_ERIZO_PIPELINE_PIPELINE_H_
 #define ERIZO_SRC_ERIZO_PIPELINE_PIPELINE_H_
 
+#include <string>
 #include <vector>
 
 #include "pipeline/HandlerContext.h"
@@ -151,6 +152,10 @@ class Pipeline : public PipelineBase {
   void close();
 
   void finalize() override;
+
+  void notifyUpdate();
+  void enable(std::string name);
+  void disable(std::string name);
 
  protected:
   Pipeline();

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -53,6 +53,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
   void updateExtensionMaps(std::array<RTPExtensions, 10> video_map, std::array<RTPExtensions, 10> audio_map);
 
@@ -85,6 +86,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   uint64_t last_remb_time_;
   bool running_;
   bool active_;
+  bool initialized_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/FecReceiverHandler.cpp
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.cpp
@@ -23,6 +23,16 @@ void FecReceiverHandler::disable() {
   enabled_ = false;
 }
 
+void FecReceiverHandler::notifyUpdate() {
+  SdpInfo &remote_sdp = connection_->getRemoteSdpInfo();
+  bool is_slide_show_mode_active = connection_->isSlideShowModeEnabled();
+  if (!remote_sdp.supportPayloadType(RED_90000_PT) || is_slide_show_mode_active) {
+    enable();
+  } else {
+    disable();
+  }
+}
+
 void FecReceiverHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
   if (enabled_ && packet->type == VIDEO_PACKET) {
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);

--- a/erizo/src/erizo/rtp/FecReceiverHandler.h
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.h
@@ -27,6 +27,7 @@ class FecReceiverHandler: public OutboundHandler, public webrtc::RtpData {
   }
 
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
   // webrtc::RtpHeader overrides.
   int32_t OnReceivedPayloadData(const uint8_t* payloadData, size_t payloadSize,

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
@@ -42,4 +42,7 @@ void RtcpProcessorHandler::write(Context *ctx, std::shared_ptr<dataPacket> packe
   }
   ctx->fireWrite(packet);
 }
+
+void RtcpProcessorHandler::notifyUpdate() {
+}
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.h
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.h
@@ -26,6 +26,7 @@ class RtcpProcessorHandler: public Handler {
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
  private:
   WebRtcConnection* connection_;

--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
@@ -26,14 +26,13 @@ class RtpAudioMuteHandler: public Handler {
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
-
+  void notifyUpdate() override;
 
  private:
   int32_t  last_original_seq_num_;
   uint16_t seq_num_offset_, last_sent_seq_num_;
 
   bool mute_is_active_;
-  std::mutex control_mutex_;
 
   WebRtcConnection* connection_;
 

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -16,6 +16,9 @@ void RtpRetransmissionHandler::enable() {
 void RtpRetransmissionHandler::disable() {
 }
 
+void RtpRetransmissionHandler::notifyUpdate() {
+}
+
 void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   // ELOG_DEBUG("%p READING %d bytes", this, packet->length);
   bool contains_nack = false;

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
@@ -26,6 +26,7 @@ class RtpRetransmissionHandler : public Handler {
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
  private:
   uint16_t getIndexInBuffer(uint16_t seq_num);

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -18,6 +18,7 @@ class RtpSlideShowHandler: public Handler {
 
   virtual void read(Context *ctx, std::shared_ptr<dataPacket> packet) = 0;
   virtual void write(Context *ctx, std::shared_ptr<dataPacket> packet) = 0;
+  virtual void notifyUpdate() = 0;
 
  protected:
   WebRtcConnection *connection_;

--- a/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpVP8SlideShowHandler.h
@@ -26,13 +26,13 @@ class RtpVP8SlideShowHandler : public RtpSlideShowHandler {
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
  private:
   int32_t slideshow_seq_num_, last_original_seq_num_;
   uint16_t seq_num_offset_;
 
   bool slideshow_is_active_, sending_keyframe_;
-  boost::mutex slideshow_mutex_;
 
   inline void setPacketSeqNumber(std::shared_ptr<dataPacket> packet, uint16_t seq_number);
 };

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -17,6 +17,9 @@ void IncomingStatsHandler::enable() {
 void IncomingStatsHandler::disable() {
 }
 
+void IncomingStatsHandler::notifyUpdate() {
+}
+
 void IncomingStatsHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (packet->data);
   if (chead->isRtcp()) {
@@ -35,6 +38,9 @@ void OutgoingStatsHandler::enable() {
 }
 
 void OutgoingStatsHandler::disable() {
+}
+
+void OutgoingStatsHandler::notifyUpdate() {
 }
 
 void OutgoingStatsHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {

--- a/erizo/src/erizo/rtp/StatsHandler.h
+++ b/erizo/src/erizo/rtp/StatsHandler.h
@@ -24,6 +24,7 @@ class IncomingStatsHandler: public InboundHandler {
   }
 
   void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
  private:
   WebRtcConnection* connection_;
@@ -43,6 +44,7 @@ class OutgoingStatsHandler: public OutboundHandler {
   }
 
   void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
 
  private:
   WebRtcConnection* connection_;

--- a/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
+++ b/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
@@ -1,7 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <rtp/RtpAudioMuteHandler.h>
+#include <rtp/BandwidthEstimationHandler.h>
 #include <rtp/RtpHeaders.h>
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -5,6 +5,7 @@
 #include <pipeline/Handler.h>
 #include <rtp/RtcpProcessor.h>
 #include <rtp/FecReceiverHandler.h>
+#include <rtp/BandwidthEstimationHandler.h>
 #include <webrtc/modules/rtp_rtcp/include/ulpfec_receiver.h>
 
 #include <string>
@@ -54,6 +55,7 @@ class Reader : public InboundHandler {
  public:
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(notifyUpdate, void());
   MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(read, void(Context*, std::shared_ptr<dataPacket>));
 };
@@ -62,6 +64,7 @@ class Writer : public OutboundHandler {
  public:
   MOCK_METHOD0(enable, void());
   MOCK_METHOD0(disable, void());
+  MOCK_METHOD0(notifyUpdate, void());
   MOCK_METHOD0(getName, std::string());
   MOCK_METHOD2(write, void(Context*, std::shared_ptr<dataPacket>));
 };


### PR DESCRIPTION
Implementing new handlers should be quite easier with this PR. All calls from WebRtcConnection will be synced with the worker thread, so it will reduce the need of mutex or similar control structures.

I've also remove the need of having another list by using Pipeline as the proxy to call handlers.