### PR TITLE
Fixed use of monotonic clock in abs_send_time rewrite

### DIFF
--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
@@ -113,8 +113,11 @@ uint32_t RtpExtensionProcessor::processAbsSendTime(char* buf) {
   auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(now);
   auto now_usec = std::chrono::duration_cast<std::chrono::microseconds>(now);
 
+  uint32_t now_usec_only = now_usec.count() - now_sec.count()*1e+6;
+
   uint8_t seconds = now_sec.count() & 0x3F;
-  uint32_t absecs = now_usec.count() * ((1LL << 18) - 1) * 1e-6;
+  uint32_t absecs = now_usec_only * ((1LL << 18) - 1) * 1e-6;
+
   absecs = (seconds << 18) + absecs;
   head->setAbsSendTime(absecs);
   return 0;


### PR DESCRIPTION
When switching to monotonic clock, we introduced a bug here where abs_send_time was not being calculated properly.
This affected cc estimation for receivers.
This should fix #718 