### PR TITLE
[BUGFIX] delete old peerConnection.

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -84,7 +84,10 @@ Erizo.Room = function (spec) {
             stream.hide();
 
             // Close PC stream
-            if (stream.pc) stream.pc.close();
+            if (stream.pc) {
+              stream.pc.close();
+              delete stream.pc;
+            }
             if (stream.local) {
                 stream.stream.stop();
             }


### PR DESCRIPTION
ATM, in a p2p call, if you unsubscribe to a stream and you try to re-subscribe you will get an error.