### PR TITLE
Fixed a bug when subscribing to only audio stream in Chrome

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -731,6 +731,9 @@ Erizo.Room = function (spec) {
             if (stream.hasVideo() || stream.hasAudio() || stream.hasScreen()) {
                 // 1- Subscribe to Stream
 
+                if (!stream.hasVideo() && !stream.hasScreen()) options.video = false;
+                if (!stream.hasAudio()) options.audio = false;
+
                 if (that.p2p) {
                     sendSDPSocket('subscribe', {streamId: stream.getID(),
                                                 metadata: options.metadata});

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -25,8 +25,8 @@ Erizo.FirefoxStack = function (spec) {
     }
 
     that.mediaConstraints = {
-        offerToReceiveAudio: spec.audio,
-        offerToReceiveVideo: spec.video,
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: true,
         mozDontOfferDataChannel: true
     };
 


### PR DESCRIPTION
If no video/audio option is specified when subscribing to a stream, we need to check if the subscribed stream has video/audio and construct the local SDP accordingly.